### PR TITLE
ci: run benchmark and upload evaluation artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,5 +82,9 @@ jobs:
           echo "Latest run: $RUN_ID"
           cat "reports/runs/$RUN_ID/metrics.json"
           
+      - name: Docker build (smoke)
+        run: |
+          docker build -f Dockerfile --target release-image -t llm-judge:ci .
+          
           
           

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,25 @@ jobs:
       - name: Tests (pytest)
         run: |
           poetry run pytest
+
+      - name: Benchmark (golden dataset)
+        run: |
+          poetry run python -m llm_judge.eval.run --spec configs/runspecs/pr_gate.yaml
+
+      - name: Upload benchmark artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-runs
+          path: reports/runs
+          if-no-files-found: error
+          
+      - name: Print benchmark metrics
+        if: always()
+        run: |
+          RUN_ID=$(ls -1t reports/runs | head -n 1)
+          echo "Latest run: $RUN_ID"
+          cat "reports/runs/$RUN_ID/metrics.json"
+          
+          
+          


### PR DESCRIPTION
Purpose: Make every PR produce evaluation artifacts + metrics so you get a continuous signal.

Outcomes
- CI runs: eval.run --spec configs/runspecs/pr_gate.yaml
- Uploads artifacts (manifest.json, judgments.jsonl, metrics.json)
- Prints a short metrics summary in CI logs
- No pass/fail threshold enforcement yet (dataset is only 5 cases)

Why this PR comes before dataset scale
Because once CI is producing artifacts, every dataset expansion automatically becomes measurable and reviewable.