### PR TITLE
fix: L2 hash mismatch between runner and graph cache

### DIFF
--- a/src/llm_judge/benchmarks/runner.py
+++ b/src/llm_judge/benchmarks/runner.py
@@ -91,6 +91,7 @@ def _evaluate_case_all_properties(
     response_text = case.request.candidate_answer
     context_parts = list(case.request.source_context or [])
     conversation_context = " ".join(msg.content for msg in case.request.conversation)
+    source_only = "\n".join(context_parts) if context_parts else ""  # EPIC 7.22/ADR-0025: raw source only, no conversation prefix
     if context_parts:
         context = (
             conversation_context
@@ -108,6 +109,7 @@ def _evaluate_case_all_properties(
         hallucination_result = check_hallucination(
             response=response_text,
             context=context,
+            source_context=source_only,  # EPIC 7.22/ADR-0025: fixes L2 hash mismatch — cache was keyed on concatenated context, not raw source
             case_id=case.case_id,
             grounding_threshold=0.8,
             min_sentence_threshold=0.3,

--- a/src/llm_judge/integrated_judge.py
+++ b/src/llm_judge/integrated_judge.py
@@ -304,6 +304,14 @@ class IntegratedJudge(JudgeEngine):
 
         context = _build_context(request, source_docs=retrieved_docs)
 
+        # EPIC 7.22/ADR-0025: provisioning hashes each doc independently; only the
+        # single-doc path (RAGTruth) produces a matchable cache key. Multi-doc left
+        # as future concern.
+        if retrieved_docs and len(retrieved_docs) == 1:
+            source_only = retrieved_docs[0]
+        else:
+            source_only = ""
+
         # =============================================================
         # Deterministic pre-checks
         # =============================================================
@@ -333,6 +341,7 @@ class IntegratedJudge(JudgeEngine):
                 hallucination_result = check_hallucination(
                     response=response_text,
                     context=context,
+                    source_context=source_only,  # EPIC 7.22/ADR-0025: L2 cache key must match provisioning hash
                     case_id=case_id,
                     grounding_threshold=gt,
                     max_ungrounded_claims=mc,


### PR DESCRIPTION
Closes #158

fix: pass source_context to check_hallucination so L2 cache hits

check_hallucination was called with context= (conversation + delimiter +
source) but without source_context=, causing source_doc inside
check_hallucination to fall through to the concatenated context. The L2
graph cache then hashed this concatenated string, which never matched
the provisioning-path hash computed from the raw source document by
kg_extraction._extract_source_text(). Result: 100% L2 cache miss on
RAGTruth-50 (F1=0.261 vs. GPT-4 baseline 0.634).

Fix: construct source_only (raw source only, no conversation, no
delimiter) at both production call sites and pass it as source_context=
to check_hallucination.

- benchmarks/runner.py: source_only = "\n".join(context_parts)
- integrated_judge.py: single-doc hash-match; multi-doc deferred

Tests in tests/unit/test_graph_cache.py already encoded the correct
pattern with source_context=self._SOURCE — the gap was integration.

Refs: EPIC 7.22, ADR-0025

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>