### PR TITLE
fix: remove MiniCheck pre-clearer from L3 fact_counting path

### DIFF
--- a/src/llm_judge/calibration/hallucination.py
+++ b/src/llm_judge/calibration/hallucination.py
@@ -807,14 +807,14 @@ def check_hallucination(
     has_unsupported = False
 
     if l3_enabled and l3_method == "fact_counting":
-        # ---- L3: MINICHECK → GEMMA FACT-COUNTING (ADR-0027) ----
-        # Two-phase L3:
-        #   L3a: MiniCheck (local, free, 78% coverage per Exp 17b)
-        #   L3b: Gemma fact-counting (API, for what MiniCheck doesn't clear)
-        # Exp 43: combined gives 76% auto-clear at 100% precision.
+        # ---- L3: GEMMA FACT-COUNTING (ADR-0027) ----
+        # Single-signal L3 per Exp 43: fc_ratio >= threshold → CLEAR, else cascade to L4.
+        # 76% auto-clear at 100% grounding precision on RAGTruth-50, 0 FN at threshold 0.8.
+        # MiniCheck is NOT run in this path — it lives in the legacy minicheck_deberta
+        # branch below, reachable via the l3_minicheck_enabled flag (ADR-0027 §Decision).
         from llm_judge.calibration.fact_counting import check_fact_counting
 
-        layer_stats["L3_minicheck"] = 0
+        layer_stats["L3_minicheck"] = 0  # kept at 0 for funnel-report compatibility
         layer_stats["L3_fact_counting_clear"] = 0
         layer_stats["L3_fact_counting_flag"] = 0
         layer_stats["L3_fact_counting_error"] = 0
@@ -823,23 +823,6 @@ def check_hallucination(
             if i in resolved:
                 continue
 
-            # L3a: MiniCheck first (local, no API cost)
-            try:
-                if _l3_minicheck(sent, source_doc):
-                    resolved.add(i)
-                    layer_stats["L3_minicheck"] += 1
-                    sentence_results.append(
-                        SentenceLayerResult(
-                            sentence_idx=i,
-                            sentence=sent[:120],
-                            resolved_by="L3_minicheck",
-                        )
-                    )
-                    continue
-            except Exception as e:
-                logger.debug(f"l3a_minicheck.error: {str(e)[:60]}")
-
-            # L3b: Gemma fact-counting (API, for sentences MiniCheck didn't clear)
             fc_result = check_fact_counting(
                 sent, source_doc, threshold=fc_clear_threshold,
             )


### PR DESCRIPTION
Closes #160

fix: remove MiniCheck pre-clearer from L3 fact_counting path

Exp 43 validated a single-signal L3 clearance rule: fc_ratio >= 0.80 →
CLEAR, else cascade to L4. That rule achieves 230/303 (76%) clearance
at 100% grounding precision on RAGTruth-50.

The production fact_counting path added a MiniCheck pre-clearer before
fact-counting, which was not part of the validated architecture.
MiniCheck cleared 48 sentences across the 12 false-negative cases in
the latest calibration run, contributing to F1=0.18 vs. an expected
floor from the validated rule.

This commit removes the MiniCheck pre-clearer from the fact_counting
path. _l3_minicheck() function is retained for the legacy
minicheck_deberta path and for future flag-corroboration experiments.

The test test_fact_counting_path_used_when_configured becomes more
reliable after this change — previously it passed because of silent
MiniCheck load failure in the test environment masking the pre-clearer;
now check_fact_counting is called unconditionally.

Refs: Exp 43, ADR-0027 (pending ADR-0029 supersession)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>