### PR TITLE
feat: runtime HALLUCINATION_LAYERS override replaces per-isolation yamls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -371,3 +371,6 @@ funnel:
 
 calibrate: preseed benchmark funnel
 	@echo "Full calibration run complete."
+
+calibrate-l1:
+	HALLUCINATION_LAYERS=l1 $(MAKE) calibrate

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -58,6 +58,12 @@ See [adr-template.md](./adr-template.md) for the template to copy.
 - **B — Baseline & Eval** — how we measure quality, store artifacts, and gate CI
 - **C — Experiment** — decisions informed by the 43-experiment research programme
 
+## Known tech debt
+
+- Delete stale pipeline yamls (`hallucination.yaml`, `hallucination_l2_only.yaml`, `hallucination_legacy.yaml`) — dead schema, silently loaded as all-defaults.
+- Add `results/` to `.gitignore` and run `git rm --cached results/benchmark_checkpoint.json`.
+- `tools/run_ragtruth50.py` preseed path passes raw `source_info` to `compute_source_hash` — crashes on QA and Data2txt cases.
+
 ## Retroactive ADRs
 
 ADRs 0002–0023 document decisions that predate the adoption of the ADR system.

--- a/tools/run_ragtruth50.py
+++ b/tools/run_ragtruth50.py
@@ -181,16 +181,44 @@ def _check_and_provision_l2(
 def cmd_benchmark(args: argparse.Namespace) -> bool:
     """Run RAGTruth-50 through the benchmark runner."""
     import os
+    from dataclasses import replace
 
     from llm_judge.benchmarks.ragtruth import RAGTruthAdapter
     from llm_judge.benchmarks.runner import run_benchmark
-    from llm_judge.calibration.pipeline_config import get_pipeline_config
+    from llm_judge.calibration.pipeline_config import LayerConfig, get_pipeline_config
 
     if not os.environ.get("GEMINI_API_KEY"):
         logger.warning("GEMINI_API_KEY not set — L3 fact-counting and L4 will fail")
 
     max_cases = args.max_cases or int(os.environ.get("BENCHMARK_MAX", "0")) or None
     config = get_pipeline_config()
+
+    # Runtime layer override — HALLUCINATION_LAYERS="l1", "l1,l2", "l1,l2,l3,l4".
+    # Listed layers enabled; unlisted disabled. Avoids per-isolation yamls.
+    layers_env = os.environ.get("HALLUCINATION_LAYERS")
+    if layers_env:
+        valid = {"l1", "l2", "l3", "l4"}
+        requested = {s.strip().lower() for s in layers_env.split(",") if s.strip()}
+        unknown = requested - valid
+        if unknown:
+            raise ValueError(
+                f"HALLUCINATION_LAYERS: unknown layer(s) {sorted(unknown)}. "
+                f"Valid: {sorted(valid)}"
+            )
+        if not requested:
+            raise ValueError("HALLUCINATION_LAYERS must name at least one layer")
+        config = replace(
+            config,
+            layers=LayerConfig(
+                l1_enabled="l1" in requested,
+                l2_enabled="l2" in requested,
+                l3_enabled="l3" in requested,
+                l4_enabled="l4" in requested,
+            ),
+        )
+        print(f"  HALLUCINATION_LAYERS override: enabled={sorted(requested)}")
+        if config.l3_method == "fact_counting" and "l3" not in requested:
+            print("  Note: l3_method='fact_counting' is dormant (L3 disabled by override)")
 
     adapter = RAGTruthAdapter()
 


### PR DESCRIPTION
Closes #165

feat: runtime HALLUCINATION_LAYERS override replaces per-isolation yamls

Previously, running the benchmark with a single layer enabled required
creating a dedicated pipeline yaml. This commit adds a runtime override
via the HALLUCINATION_LAYERS env var, eliminating the need for new yaml
files per isolation experiment.

Changes:
1. tools/run_ragtruth50.py parses HALLUCINATION_LAYERS (e.g. "l1",
   "l1,l2") and overrides config.layers after load. Validator constraint
   for l3_method=fact_counting auto-relaxes when the override disables
   L3 (the field is dormant when L3 is off).

2. Makefile calibrate-l1 target simplifies to HALLUCINATION_LAYERS=l1
   $(MAKE) calibrate. Same pattern will extend to l1,l2 etc.

3. Deletes configs/pipeline/hallucination_l1_only.yaml (obsolete under
   runtime override).

4. Documents three tech-debt items in docs/adr/README.md: stale pipeline
   yamls, results/ gitignore, preseed source_info bug.

Refs: Exp 29B, ADR-0027