### PR TITLE
fix: include sentence_level_metrics in run_ragtruth50 output JSON

### DIFF
--- a/tests/unit/test_benchmarks.py
+++ b/tests/unit/test_benchmarks.py
@@ -225,3 +225,62 @@ class TestRAGTruthAdapter:
 
         cases = list(adapter.load_cases(split="test", max_cases=1))
         assert len(cases) == 1
+
+
+class TestRunRagtruth50Serializer:
+    """Regression guard: run_ragtruth50.py cmd_benchmark must serialize all
+    fields of BenchmarkRunResult that downstream consumers depend on.
+    Added after #167: sentence_level_metrics was computed but silently
+    dropped by the hand-built summary dict."""
+
+    def test_sentence_level_metrics_in_output(self, tmp_path, monkeypatch):
+        import argparse
+        import importlib.util
+        from pathlib import Path as _Path
+
+        repo_root = _Path(__file__).resolve().parents[2]
+        module_path = repo_root / "tools" / "run_ragtruth50.py"
+        spec = importlib.util.spec_from_file_location("run_ragtruth50", module_path)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        stub_metrics = {
+            "overall": {"precision": 0.91, "recall": 0.42, "f1": 0.57},
+            "by_layer": {"l1": {"tp": 10, "fp": 1, "fn": 14}},
+        }
+        stub_result = BenchmarkRunResult(
+            benchmark_name="RAGTruth",
+            split="test",
+            cases_evaluated=1,
+            elapsed_seconds=0.1,
+            response_level_results=[],
+            sentence_level_metrics=stub_metrics,
+        )
+
+        class _StubAdapter:
+            def set_benchmark_filter(self, *_args, **_kwargs):
+                pass
+
+        monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(
+            "llm_judge.benchmarks.ragtruth.RAGTruthAdapter", lambda: _StubAdapter()
+        )
+        monkeypatch.setattr(
+            "llm_judge.benchmarks.runner.run_benchmark",
+            lambda *_a, **_kw: stub_result,
+        )
+        monkeypatch.setenv("HALLUCINATION_LAYERS", "l1")
+        monkeypatch.setenv("GEMINI_API_KEY", "stub")
+        monkeypatch.chdir(tmp_path)  # datasets/benchmarks/... won't exist → skip prereq
+
+        args = argparse.Namespace(
+            max_cases=1, gate2_routing="pass", with_llm=False
+        )
+        assert module.cmd_benchmark(args) is True
+
+        written = json.loads(
+            (tmp_path / "results" / "ragtruth50_results.json").read_text()
+        )
+        assert "sentence_level_metrics" in written
+        assert written["sentence_level_metrics"] == stub_metrics

--- a/tools/run_ragtruth50.py
+++ b/tools/run_ragtruth50.py
@@ -268,6 +268,7 @@ def cmd_benchmark(args: argparse.Namespace) -> bool:
         "fire_rates": result.fire_rates,
         "diagnostic_results": result.diagnostic_results,
         "response_level_results": result.response_level_results,
+        "sentence_level_metrics": result.sentence_level_metrics,
     }
 
     results_path.write_text(json.dumps(summary, indent=2, default=str))


### PR DESCRIPTION
## Summary

- `BenchmarkRunResult.sentence_level_metrics` is correctly populated by `runner.py:992`, but `tools/run_ragtruth50.py:cmd_benchmark` built its `summary` dict by hand and omitted the field — so the metric never reached `results/ragtruth50_results.json`. This completes the intent of #162/#164.
- Adds the missing key to the summary dict.
- Adds a regression test that exercises `cmd_benchmark` end-to-end with stubbed dependencies and asserts the field round-trips through the written JSON.

## Test plan

- [x] `poetry run pytest tests/unit/test_benchmarks.py::TestRunRagtruth50Serializer -xvs` — new test passes
- [x] `poetry run pytest tests/unit/ -x` — full suite green (722 passed)
- [ ] After merge: `make calibrate-l1` from clean master produces `results/ragtruth50_results.json` containing `sentence_level_metrics`

Closes #167