### PR TITLE
fix: L2 G5 builder contract — normalize P5 str→dict, isolate builders

### DIFF
--- a/src/llm_judge/calibration/graph_cache.py
+++ b/src/llm_judge/calibration/graph_cache.py
@@ -40,6 +40,80 @@ def compute_source_hash(source_text: str) -> str:
     return hashlib.sha256(source_text.encode("utf-8")).hexdigest()
 
 
+# P5 fields where Gemini multi-pass extraction sometimes emits bare strings
+# where the builders expect dicts. Normalizing at the cache-load boundary
+# keeps the build_g5_negations contract simple (always dict) and isolates
+# shape drift to a single, observable site. See #179.
+_P5_STR_SCHEMAS: dict[str, tuple[str, dict[str, str]]] = {
+    # field name -> (key to fill with the string, extra fixed keys)
+    "explicit_negations": ("statement", {}),
+    "absent_information": ("what", {}),
+    "corrections": ("wrong", {"right": ""}),
+}
+
+
+def _normalize_fact_table(data: dict[str, Any]) -> dict[str, Any]:
+    """
+    Normalize fact-table element shapes at the cache-load boundary.
+
+    Gemini multi-pass extraction sometimes emits bare strings where
+    ``build_g5_negations`` expects dicts. This function coerces the
+    three known shape-drift fields in P5 into canonical dicts so
+    downstream builders can rely on ``.get()`` succeeding.
+
+    Schema (P5 only — P1–P4 pass through untouched by current contract):
+      * ``P5_negations.explicit_negations``:
+          ``"no lighting"`` → ``{"statement": "no lighting"}``
+      * ``P5_negations.absent_information``:
+          ``"missing info"`` → ``{"what": "missing info"}``
+      * ``P5_negations.corrections``:
+          ``"correction text"`` →
+          ``{"wrong": "correction text", "right": ""}``
+          (The empty ``right`` causes ``build_g5_negations`` to drop
+          the entry via its ``if wrong and right`` guard — acceptable:
+          the normalizer preserves shape, not semantics. Semantic
+          recovery of bare-string corrections is out of scope.)
+
+    Unknown element types (neither str nor dict) are dropped with a
+    WARNING log — never silently — so that drift beyond these fields
+    stays observable.
+
+    In-place, idempotent. Returns the same dict.
+    """
+    passes = data.get("passes", data)
+    if not isinstance(passes, dict):
+        return data
+
+    p5 = passes.get("P5_negations")
+    if not isinstance(p5, dict):
+        return data
+
+    for field, (primary_key, extras) in _P5_STR_SCHEMAS.items():
+        raw = p5.get(field)
+        if not isinstance(raw, list):
+            continue
+        normalized: list[dict[str, Any]] = []
+        for idx, elem in enumerate(raw):
+            if isinstance(elem, dict):
+                normalized.append(elem)
+            elif isinstance(elem, str):
+                shaped: dict[str, Any] = {primary_key: elem}
+                shaped.update(extras)
+                normalized.append(shaped)
+            else:
+                logger.warning(
+                    "graph_cache.normalize_unknown_element",
+                    extra={
+                        "field": f"P5_negations.{field}",
+                        "index": idx,
+                        "type": type(elem).__name__,
+                    },
+                )
+        p5[field] = normalized
+
+    return data
+
+
 class GraphCache:
     """
     Filesystem-backed cache for L2 fact tables.
@@ -125,6 +199,7 @@ class GraphCache:
 
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
+            data = _normalize_fact_table(data)
             self._hits += 1
             return data
         except (json.JSONDecodeError, OSError) as e:
@@ -143,6 +218,7 @@ class GraphCache:
             return None
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
+            data = _normalize_fact_table(data)
             self._hits += 1
             return data
         except (json.JSONDecodeError, OSError):

--- a/src/llm_judge/calibration/hallucination_graphs.py
+++ b/src/llm_judge/calibration/hallucination_graphs.py
@@ -219,13 +219,17 @@ def build_g4_numbers(p4: dict):  # returns nx.DiGraph
 
 
 def build_g5_negations(p5: dict):  # returns nx.DiGraph
-    """Graph from P5: negation statements, absent info, corrections."""
+    """Graph from P5: negation statements, absent info, corrections.
+
+    Assumes list elements are dicts — shape is guaranteed upstream by
+    ``graph_cache._normalize_fact_table``.
+    """
     import networkx as nx
 
     G = nx.DiGraph()
     G.add_node("_negation_root", node_type="root")
     for neg in _safe_list(p5.get("explicit_negations")):
-        stmt = (neg.get("statement") or str(neg) or "").lower().strip()
+        stmt = (neg.get("statement") or "").lower().strip()
         if stmt:
             G.add_node(f"neg_{hash(stmt)%99999}", node_type="negation", statement=stmt)
             G.add_edge(
@@ -235,7 +239,7 @@ def build_g5_negations(p5: dict):  # returns nx.DiGraph
                 polarity="negate",
             )
     for absent in _safe_list(p5.get("absent_information")):
-        what = (absent.get("what") or str(absent) or "").lower().strip()
+        what = (absent.get("what") or "").lower().strip()
         if what:
             G.add_node(f"absent_{hash(what)%99999}", node_type="absent", what=what)
             G.add_edge(
@@ -263,8 +267,36 @@ def build_g5_negations(p5: dict):  # returns nx.DiGraph
     return G
 
 
+def _build_graph_isolated(name: str, builder, *args):
+    """Run one graph builder; on failure return an empty DiGraph and WARN.
+
+    Isolates per-builder failures so a bug in one graph does not take
+    down the entire L2 ensemble. Surfaces the failure via a WARNING log
+    with the specific graph name and exception type (see #179).
+    """
+    import networkx as nx
+
+    try:
+        return builder(*args)
+    except Exception as e:
+        logger.warning(
+            "build_all_graphs.builder_failed",
+            extra={
+                "graph": name,
+                "error_type": type(e).__name__,
+                "error": str(e)[:120],
+            },
+        )
+        return nx.DiGraph()
+
+
 def build_all_graphs(fact_tables: dict) -> dict:
-    """Build all 5 graphs from multi-pass fact tables."""
+    """Build all 5 graphs from multi-pass fact tables.
+
+    Per-builder isolation: if one builder raises, it returns an empty
+    graph and the others still run. The failure is logged at WARNING
+    with the graph name and exception type.
+    """
     passes = fact_tables.get("passes", fact_tables)
     p1 = passes.get("P1_entities")
     p2 = passes.get("P2_events")
@@ -273,15 +305,15 @@ def build_all_graphs(fact_tables: dict) -> dict:
     p5 = passes.get("P5_negations")
     graphs = {}
     if p1:
-        graphs["G1"] = build_g1_entities(p1)
+        graphs["G1"] = _build_graph_isolated("G1", build_g1_entities, p1)
     if p2:
-        graphs["G2"] = build_g2_events(p2, p1)
+        graphs["G2"] = _build_graph_isolated("G2", build_g2_events, p2, p1)
     if p3:
-        graphs["G3"] = build_g3_relationships(p3)
+        graphs["G3"] = _build_graph_isolated("G3", build_g3_relationships, p3)
     if p4:
-        graphs["G4"] = build_g4_numbers(p4)
+        graphs["G4"] = _build_graph_isolated("G4", build_g4_numbers, p4)
     if p5:
-        graphs["G5"] = build_g5_negations(p5)
+        graphs["G5"] = _build_graph_isolated("G5", build_g5_negations, p5)
     return graphs
 
 

--- a/tests/unit/test_build_all_graphs_isolation.py
+++ b/tests/unit/test_build_all_graphs_isolation.py
@@ -1,0 +1,151 @@
+"""
+Per-builder isolation tests for ``build_all_graphs`` (#179).
+
+Asserts that when one of the five graph builders raises, the remaining
+four still succeed and a WARNING is logged with the specific graph name
+and exception type. Pre-fix, a single bad pass took the entire L2
+ensemble down silently (see ``docs/sessions/session_continuity_brief_2026-04-21.md``).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+import llm_judge.calibration.hallucination_graphs as hg
+
+
+def _make_fact_tables() -> dict:
+    """Minimum non-empty inputs for every builder."""
+    return {
+        "passes": {
+            "P1_entities": {"entities": [{"name": "Alice", "type": "person"}]},
+            "P2_events": {
+                "events": [{"who": "Alice", "action": "visited", "target": "Paris"}]
+            },
+            "P3_relationships": {
+                "relationships": [
+                    {"entity1": "Alice", "entity2": "Bob", "relationship": "friend"}
+                ]
+            },
+            "P4_numbers": {
+                "numerical_facts": [
+                    {"entity": "Alice", "number": "3", "describes": "books"}
+                ],
+                "temporal_facts": [],
+            },
+            "P5_negations": {
+                "explicit_negations": [{"statement": "Alice is not a cat"}],
+                "absent_information": [],
+                "corrections": [],
+            },
+        }
+    }
+
+
+class TestBuildAllGraphsIsolation:
+    """One builder raises → others still run + WARNING names the bad graph."""
+
+    @pytest.mark.parametrize(
+        "target",
+        ["build_g1_entities", "build_g2_events", "build_g3_relationships",
+         "build_g4_numbers", "build_g5_negations"],
+    )
+    def test_single_builder_failure_isolated(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+        target: str,
+    ) -> None:
+        expected_graph = {
+            "build_g1_entities": "G1",
+            "build_g2_events": "G2",
+            "build_g3_relationships": "G3",
+            "build_g4_numbers": "G4",
+            "build_g5_negations": "G5",
+        }[target]
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError(f"simulated {target} failure")
+
+        monkeypatch.setattr(hg, target, _boom)
+
+        with caplog.at_level(logging.WARNING, logger="llm_judge.calibration.hallucination_graphs"):
+            graphs = hg.build_all_graphs(_make_fact_tables())
+
+        # All five graphs still present; the bad one is empty.
+        assert set(graphs.keys()) == {"G1", "G2", "G3", "G4", "G5"}
+        assert graphs[expected_graph].number_of_nodes() == 0, (
+            f"{expected_graph} should be empty (builder raised), got "
+            f"{graphs[expected_graph].number_of_nodes()} nodes"
+        )
+
+        # Others still built their graphs (non-empty).
+        for name, G in graphs.items():
+            if name == expected_graph:
+                continue
+            # G2 can be empty if its input was empty; here we supplied data for all
+            assert G.number_of_nodes() > 0, (
+                f"{name} should be non-empty after {expected_graph} failed, "
+                f"got 0 nodes — failure was not isolated"
+            )
+
+        # WARNING was logged with the specific graph name + exception type.
+        warns = [r for r in caplog.records if r.levelno == logging.WARNING]
+        graph_field = [getattr(r, "graph", None) for r in warns]
+        err_field = [getattr(r, "error_type", None) for r in warns]
+        assert expected_graph in graph_field, (
+            f"WARNING must name graph={expected_graph}; got {graph_field}"
+        )
+        assert "RuntimeError" in err_field, (
+            f"WARNING must include error_type=RuntimeError; got {err_field}"
+        )
+
+    def test_no_failure_no_warnings(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Clean path: when all builders succeed, no WARNING fires."""
+        with caplog.at_level(logging.WARNING, logger="llm_judge.calibration.hallucination_graphs"):
+            graphs = hg.build_all_graphs(_make_fact_tables())
+
+        assert set(graphs.keys()) == {"G1", "G2", "G3", "G4", "G5"}
+        assert all(G.number_of_nodes() > 0 for G in graphs.values())
+
+        warns = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert not warns, (
+            f"no WARNINGs expected on clean path; got {[r.getMessage() for r in warns]}"
+        )
+
+
+class TestP5StringsAcceptedPostNormalization:
+    """Regression guard: G5 no longer raises on bare-string P5 elements.
+
+    The *cache* normalizes shape, so at the build layer the data is dict.
+    But if a caller somehow passes un-normalized P5, the per-builder
+    isolation still keeps the other four alive.
+    """
+
+    def test_raw_str_p5_isolated_not_fatal(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        ft = _make_fact_tables()
+        ft["passes"]["P5_negations"]["explicit_negations"] = [
+            "did not survive to March 1945",  # bare str — bypasses normalizer
+        ]
+
+        with caplog.at_level(logging.WARNING, logger="llm_judge.calibration.hallucination_graphs"):
+            graphs = hg.build_all_graphs(ft)
+
+        # G5 emptied (builder raised on .get() against str), but G1-G4 survive.
+        assert graphs["G5"].number_of_nodes() == 0
+        for name in ("G1", "G2", "G3", "G4"):
+            assert graphs[name].number_of_nodes() > 0
+
+        # WARNING names G5 + AttributeError.
+        warns = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(
+            getattr(r, "graph", None) == "G5"
+            and getattr(r, "error_type", None) == "AttributeError"
+            for r in warns
+        ), f"expected G5/AttributeError WARNING; got {[(getattr(r,'graph',None), getattr(r,'error_type',None)) for r in warns]}"

--- a/tests/unit/test_graph_cache_normalization.py
+++ b/tests/unit/test_graph_cache_normalization.py
@@ -1,0 +1,212 @@
+"""
+Silence-contract tests for graph_cache normalization boundary (#179).
+
+Asserts that ``GraphCache.get()`` / ``get_by_hash()`` either return a
+fully normalized fact-table (P5 str elements coerced to canonical dicts)
+or surface the problem — never silently returns malformed data that
+would later crash ``build_g5_negations``.
+
+Companion: ``tests/unit/test_p5_normalization.py`` (unit-level schema
+assertions); ``tests/unit/test_build_all_graphs_isolation.py``
+(per-builder failure isolation).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from llm_judge.calibration.graph_cache import (
+    GraphCache,
+    compute_source_hash,
+)
+
+# =====================================================================
+# Fixtures — malformed fact tables the old G5 would crash on
+# =====================================================================
+
+
+def _write_entry(cache: GraphCache, source_text: str, data: dict) -> Path:
+    source_hash = compute_source_hash(source_text)
+    path = cache.cache_dir / f"{source_hash}.json"
+    cache.cache_dir.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+_MIXED_P5 = {
+    "passes": {
+        "P1_entities": {"entities": []},
+        "P2_events": {"events": []},
+        "P3_relationships": {"relationships": []},
+        "P4_numbers": {"numerical_facts": [], "temporal_facts": []},
+        "P5_negations": {
+            # Mix: strings (drift) and dicts (clean)
+            "explicit_negations": [
+                "did not survive to March 1945",
+                {"statement": "no electricity in the camp"},
+            ],
+            "absent_information": [
+                "The exact dates of death remain unclear.",
+                {"what": "Method of execution"},
+            ],
+            "corrections": [
+                "A said X but source says Y.",
+                {"wrong": "previously thought", "right": "in fact"},
+            ],
+        },
+    }
+}
+
+
+# =====================================================================
+# Silence contract: get() must return normalized data, never raw drift
+# =====================================================================
+
+
+class TestGetNeverReturnsStrElements:
+    """Post-get(), no P5 list contains a bare string. Drift is invisible downstream."""
+
+    def test_get_normalizes_explicit_negations(self, tmp_path: Path) -> None:
+        cache = GraphCache(tmp_path)
+        _write_entry(cache, "src-neg", _MIXED_P5)
+
+        result = cache.get("src-neg")
+
+        assert result is not None
+        p5 = result["passes"]["P5_negations"]
+        for elem in p5["explicit_negations"]:
+            assert isinstance(elem, dict), f"bare string leaked past get(): {elem!r}"
+            assert "statement" in elem
+
+    def test_get_normalizes_absent_information(self, tmp_path: Path) -> None:
+        cache = GraphCache(tmp_path)
+        _write_entry(cache, "src-absent", _MIXED_P5)
+
+        result = cache.get("src-absent")
+
+        assert result is not None
+        for elem in result["passes"]["P5_negations"]["absent_information"]:
+            assert isinstance(elem, dict)
+            assert "what" in elem
+
+    def test_get_normalizes_corrections(self, tmp_path: Path) -> None:
+        cache = GraphCache(tmp_path)
+        _write_entry(cache, "src-corr", _MIXED_P5)
+
+        result = cache.get("src-corr")
+
+        assert result is not None
+        for elem in result["passes"]["P5_negations"]["corrections"]:
+            assert isinstance(elem, dict)
+            assert "wrong" in elem
+            assert "right" in elem
+
+    def test_get_by_hash_also_normalizes(self, tmp_path: Path) -> None:
+        """The second public read path must honor the same contract."""
+        cache = GraphCache(tmp_path)
+        src = "by-hash-source"
+        source_hash = compute_source_hash(src)
+        _write_entry(cache, src, _MIXED_P5)
+
+        result = cache.get_by_hash(source_hash)
+
+        assert result is not None
+        for elem in result["passes"]["P5_negations"]["explicit_negations"]:
+            assert isinstance(elem, dict)
+
+
+# =====================================================================
+# Clean pass-through: already-dict P5 entries are unchanged
+# =====================================================================
+
+
+class TestGetPassesThroughCleanData:
+    """When P5 is already dicts, get() must not mutate shape."""
+
+    def test_dicts_only_unchanged(self, tmp_path: Path) -> None:
+        cache = GraphCache(tmp_path)
+        clean = {
+            "passes": {
+                "P5_negations": {
+                    "explicit_negations": [{"statement": "no X"}],
+                    "absent_information": [{"what": "no info"}],
+                    "corrections": [{"wrong": "A", "right": "B"}],
+                }
+            }
+        }
+        _write_entry(cache, "clean", clean)
+
+        result = cache.get("clean")
+
+        assert result is not None
+        p5 = result["passes"]["P5_negations"]
+        assert p5["explicit_negations"] == [{"statement": "no X"}]
+        assert p5["absent_information"] == [{"what": "no info"}]
+        assert p5["corrections"] == [{"wrong": "A", "right": "B"}]
+
+
+# =====================================================================
+# Unknown-type contract: WARNING, never silent
+# =====================================================================
+
+
+class TestUnknownElementTypeSurfacesWarning:
+    """Drift beyond str/dict (e.g., int, list) must not be silently dropped."""
+
+    def test_int_element_logs_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        cache = GraphCache(tmp_path)
+        weird = {
+            "passes": {
+                "P5_negations": {
+                    "explicit_negations": [42, "a valid str neg"],
+                    "absent_information": [],
+                    "corrections": [],
+                }
+            }
+        }
+        _write_entry(cache, "weird", weird)
+
+        with caplog.at_level(logging.WARNING, logger="llm_judge.calibration.graph_cache"):
+            result = cache.get("weird")
+
+        assert result is not None
+        p5 = result["passes"]["P5_negations"]
+        # Int was dropped; valid string was normalized.
+        assert len(p5["explicit_negations"]) == 1
+        assert p5["explicit_negations"][0] == {"statement": "a valid str neg"}
+        # But the drop was loud — WARNING recorded with type + field.
+        warns = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(
+            "normalize_unknown_element" in r.getMessage()
+            or getattr(r, "type", None) == "int"
+            for r in warns
+        ), f"expected WARNING for int element; got {[r.getMessage() for r in warns]}"
+
+
+# =====================================================================
+# Malformed JSON path remains loud (pre-existing contract, not regressed)
+# =====================================================================
+
+
+class TestCorruptEntryStillWarns:
+    """Normalization must not swallow the existing corrupt-file WARNING."""
+
+    def test_corrupt_json_logs_read_error(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        cache = GraphCache(tmp_path)
+        cache.cache_dir.mkdir(parents=True, exist_ok=True)
+        source_hash = compute_source_hash("corrupt-source")
+        (cache.cache_dir / f"{source_hash}.json").write_text("{not json")
+
+        with caplog.at_level(logging.WARNING, logger="llm_judge.calibration.graph_cache"):
+            result = cache.get("corrupt-source")
+
+        assert result is None
+        assert any("read_error" in r.getMessage() for r in caplog.records)

--- a/tests/unit/test_p5_normalization.py
+++ b/tests/unit/test_p5_normalization.py
@@ -1,0 +1,245 @@
+"""
+Unit tests for the P5 fact-table normalizer (#179).
+
+Three core assertions as requested:
+  1. Mixed shape handling — str and dict elements coexist; both end as dicts.
+  2. Corrections str case — str → {"wrong": s, "right": ""}; dropped by guard downstream.
+  3. Unknown type handling — neither str nor dict → WARNING, not silent drop.
+
+The normalizer is private; we exercise it via its public entry points
+``GraphCache.get`` / ``get_by_hash`` (i.e., the contract, not the symbol).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from llm_judge.calibration.graph_cache import GraphCache, compute_source_hash
+from llm_judge.calibration.hallucination_graphs import build_g5_negations
+
+
+def _write(cache: GraphCache, src: str, data: dict) -> None:
+    cache.cache_dir.mkdir(parents=True, exist_ok=True)
+    (cache.cache_dir / f"{compute_source_hash(src)}.json").write_text(
+        json.dumps(data), encoding="utf-8"
+    )
+
+
+# =====================================================================
+# 1. Mixed shape handling
+# =====================================================================
+
+
+class TestMixedShape:
+    """str and dict elements in the same list both survive as dicts."""
+
+    def test_mixed_explicit_negations(self, tmp_path: Path) -> None:
+        cache = GraphCache(tmp_path)
+        _write(cache, "mix-neg", {
+            "passes": {
+                "P5_negations": {
+                    "explicit_negations": [
+                        "no lighting",
+                        {"statement": "no water", "detail": "reservoir empty"},
+                        "no latrine",
+                    ],
+                    "absent_information": [],
+                    "corrections": [],
+                }
+            }
+        })
+
+        result = cache.get("mix-neg")
+        assert result is not None
+        negs = result["passes"]["P5_negations"]["explicit_negations"]
+
+        assert len(negs) == 3
+        assert negs[0] == {"statement": "no lighting"}
+        assert negs[1] == {"statement": "no water", "detail": "reservoir empty"}
+        assert negs[2] == {"statement": "no latrine"}
+
+        # And the downstream builder now succeeds on all three.
+        G = build_g5_negations(result["passes"]["P5_negations"])
+        negation_nodes = [
+            n for n, d in G.nodes(data=True) if d.get("node_type") == "negation"
+        ]
+        assert len(negation_nodes) == 3
+
+    def test_mixed_absent_information(self, tmp_path: Path) -> None:
+        cache = GraphCache(tmp_path)
+        _write(cache, "mix-abs", {
+            "passes": {
+                "P5_negations": {
+                    "explicit_negations": [],
+                    "absent_information": [
+                        "date unclear",
+                        {"what": "method unknown"},
+                    ],
+                    "corrections": [],
+                }
+            }
+        })
+
+        result = cache.get("mix-abs")
+        assert result is not None
+        items = result["passes"]["P5_negations"]["absent_information"]
+
+        assert items[0] == {"what": "date unclear"}
+        assert items[1] == {"what": "method unknown"}
+
+        G = build_g5_negations(result["passes"]["P5_negations"])
+        absent_nodes = [
+            n for n, d in G.nodes(data=True) if d.get("node_type") == "absent"
+        ]
+        assert len(absent_nodes) == 2
+
+
+# =====================================================================
+# 2. Corrections str case (shape preserved, semantics dropped by guard)
+# =====================================================================
+
+
+class TestCorrectionsStrShape:
+    """str correction → {"wrong": s, "right": ""}. Guard in build_g5 drops it."""
+
+    def test_str_correction_shaped_with_empty_right(self, tmp_path: Path) -> None:
+        cache = GraphCache(tmp_path)
+        _write(cache, "str-corr", {
+            "passes": {
+                "P5_negations": {
+                    "explicit_negations": [],
+                    "absent_information": [],
+                    "corrections": [
+                        "Anne died a month earlier than previously thought.",
+                        {"wrong": "previously thought", "right": "in fact"},
+                    ],
+                }
+            }
+        })
+
+        result = cache.get("str-corr")
+        assert result is not None
+        corrs = result["passes"]["P5_negations"]["corrections"]
+
+        # Shape preserved: str became {"wrong": s, "right": ""}.
+        assert corrs[0] == {
+            "wrong": "Anne died a month earlier than previously thought.",
+            "right": "",
+        }
+        # Clean dict unchanged.
+        assert corrs[1] == {"wrong": "previously thought", "right": "in fact"}
+
+    def test_guard_drops_str_corrections_in_builder(self, tmp_path: Path) -> None:
+        """Downstream build_g5_negations' `if wrong and right` guard drops empty-right
+        entries. This is the documented, acceptable loss of semantic recovery."""
+        cache = GraphCache(tmp_path)
+        _write(cache, "drop-check", {
+            "passes": {
+                "P5_negations": {
+                    "explicit_negations": [],
+                    "absent_information": [],
+                    "corrections": [
+                        "bare string correction 1",
+                        "bare string correction 2",
+                        {"wrong": "A", "right": "B"},
+                    ],
+                }
+            }
+        })
+
+        result = cache.get("drop-check")
+        assert result is not None
+        G = build_g5_negations(result["passes"]["P5_negations"])
+
+        correction_nodes = [
+            n for n, d in G.nodes(data=True) if d.get("node_type") == "correction"
+        ]
+        # Only the dict survives the `if wrong and right` guard. The two str
+        # cases entered as {"wrong": s, "right": ""} and dropped. No crash.
+        assert len(correction_nodes) == 1
+
+
+# =====================================================================
+# 3. Unknown type handling — WARNING, never silent drop
+# =====================================================================
+
+
+class TestUnknownTypeSurfacesWarning:
+    """Neither str nor dict must emit a WARNING (not a silent skip)."""
+
+    @pytest.mark.parametrize(
+        "weird_element,expected_type",
+        [
+            (42, "int"),
+            (["nested", "list"], "list"),
+            (None, "NoneType"),
+            (3.14, "float"),
+        ],
+    )
+    def test_unknown_types_log_warning(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+        weird_element,
+        expected_type: str,
+    ) -> None:
+        cache = GraphCache(tmp_path)
+        _write(cache, f"weird-{expected_type}", {
+            "passes": {
+                "P5_negations": {
+                    "explicit_negations": [weird_element, "valid str"],
+                    "absent_information": [],
+                    "corrections": [],
+                }
+            }
+        })
+
+        with caplog.at_level(logging.WARNING, logger="llm_judge.calibration.graph_cache"):
+            result = cache.get(f"weird-{expected_type}")
+
+        assert result is not None
+        negs = result["passes"]["P5_negations"]["explicit_negations"]
+        # The weird element was dropped; the str was still normalized.
+        assert negs == [{"statement": "valid str"}]
+
+        # And a WARNING was recorded that names the field + type.
+        warns = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(
+            getattr(r, "type", None) == expected_type
+            and "explicit_negations" in str(getattr(r, "field", ""))
+            for r in warns
+        ), (
+            f"expected WARNING with type={expected_type} and field containing "
+            f"'explicit_negations'; got {[(getattr(r,'type',None), getattr(r,'field',None)) for r in warns]}"
+        )
+
+    def test_known_types_do_not_warn(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Sanity: str and dict inputs trigger no 'unknown_element' WARNING."""
+        cache = GraphCache(tmp_path)
+        _write(cache, "known-only", {
+            "passes": {
+                "P5_negations": {
+                    "explicit_negations": ["a", {"statement": "b"}],
+                    "absent_information": [],
+                    "corrections": [],
+                }
+            }
+        })
+
+        with caplog.at_level(logging.WARNING, logger="llm_judge.calibration.graph_cache"):
+            cache.get("known-only")
+
+        unknown_warns = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING and "normalize_unknown_element" in r.getMessage()
+        ]
+        assert not unknown_warns, (
+            f"no 'normalize_unknown_element' WARNING expected on clean data; "
+            f"got {[r.getMessage() for r in unknown_warns]}"
+        )


### PR DESCRIPTION
## Summary

Fixes **#179** — L2 swallow + G5 schema drift. Three independent changes:

1. **`graph_cache._normalize_fact_table`** coerces Gemini P5 shape drift at the cache-load boundary. Inventory across all 9 cached tables: P5 is overwhelmingly `str` (76/87 elements) but mixed with `dict` (11/87). P1–P4 pass through untouched. Called from `cache.get()` and `cache.get_by_hash()`.

   | field | str shape | canonical dict |
   |---|---|---|
   | `explicit_negations` | `"no lighting"` | `{"statement": "no lighting"}` |
   | `absent_information` | `"dates unclear"` | `{"what": "dates unclear"}` |
   | `corrections` | `"A says X not Y"` | `{"wrong": "A says X not Y", "right": ""}` (empty `right` → dropped by downstream guard; shape preserved, semantic recovery intentionally out of scope) |

   Unknown element types (`int`, `list`, `None`, etc.) drop with a WARNING log — never silent.

2. **Per-builder isolation in `build_all_graphs`** — each of the five builders is wrapped in try/except via `_build_graph_isolated`. On failure: empty DiGraph for that builder, WARNING with graph name + exception type, others continue. Pre-fix, a G5 raise took down the whole ensemble (swallow at `hallucination.py:742` discarded the stack trace).

3. **Deleted dead `or str(neg) or ""` fallback** in `build_g5_negations` — `.get()` raises before the `or` short-circuit evaluates, so the fallback was unreachable. Normalization upstream makes dict shape guaranteed.

## Silence-contract tests (L65 / L68 — silent skip is the worst failure mode)

- `tests/unit/test_graph_cache_normalization.py` — `cache.get()` never returns malformed data (bare `str` elements invisible downstream).
- `tests/unit/test_build_all_graphs_isolation.py` — parametrised per builder: one raises → others survive, WARNING names the graph.
- `tests/unit/test_p5_normalization.py` — mixed shape, corrections-str case, unknown-type WARNING.

## Local parity measurement on `tests/integration/test_l2_exp31_parity.py` (PR #182)

| metric | pre-fix | post-fix | target | Δ |
|---|---|---|---|---|
| L2 grounded | 16 | **43** | 61 ± 1 | **+27** |
| catches | 5 | **8** | 11 | **+3** |
| combined L1+L2 clearance | 35 | **62** | 78 ± 2 | **+27** |
| safety_violations | 0 | 1 | 0 | +1 |

**0 of the 9 failing assertions in PR #182 went fully green** — tolerances are strict and the remaining gap blocks on #180 (preseed silent-skip) and #181 (L4 default label). But the underlying numbers moved substantially: 63% of the grounded gap closed, 50% of the catches gap closed.

**Note on the `safety_violations 0 → 1` change**: pre-fix, L2 was completely dead for 8 of 9 cache entries (G5 raise killed the ensemble), so `safety_violations=0` was a false green. Post-fix, L2 actually runs on all entries, exposing one real false positive. The previously-passing assertion regressed because the underlying behavior changed from "absent" to "present-but-imperfect" — which is the correct direction.

## Regression check

- `tests/unit/test_hallucination_graphs.py`: **56/56 green**
- `tests/unit/test_graph_cache.py`: **32/32 green**
- New: **23/23 green**
- No regression.

## Unblocks

- PR #182's parity test moves from `9 fail / 11 pass` toward parity. Remaining blockers: #180, #181.

Closes #179

## Test plan

- [x] All new unit tests green locally
- [x] No regression in existing `test_hallucination_graphs.py` / `test_graph_cache.py`
- [x] Parity measurement captured and reported honestly
- [ ] 7-check governance gate green on CI
- [ ] Human review before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)