### PR TITLE
fix(preseed): make Exp 31 preseed coverage loud by default (#180)

### DIFF
--- a/src/llm_judge/calibration/graph_cache.py
+++ b/src/llm_judge/calibration/graph_cache.py
@@ -322,62 +322,114 @@ class GraphCache:
 # =====================================================================
 
 
+class FactTableValidationError(ValueError):
+    """Raised when preseed cannot satisfy its coverage contract.
+
+    Surfaces the gap between the caller's declared case universe
+    (``source_texts`` keys) and the Exp 31 fact-table catalog. Silent
+    skips here masked a 48/50 RAGTruth-50 preseed gap for two quarters
+    (see #180). Loud-by-default is the fix.
+    """
+
+
 def preseed_from_exp31(
     cache: GraphCache,
     exp31_path: Path | str,
     source_texts: dict[str, str],
+    *,
+    strict: bool = False,
 ) -> dict[str, Any]:
     """
     Pre-seed the graph cache from Exp 31 multipass fact tables.
+
+    Iterates the caller's ``source_texts`` (the declared case universe),
+    not the Exp 31 file, so every miss is surfaced by case_id. The prior
+    behavior iterated Exp 31 and silently skipped source_texts entries
+    with no matching fact table (#180).
 
     Args:
         cache: The GraphCache instance to seed.
         exp31_path: Path to exp31_multipass_fact_tables.json.
         source_texts: Mapping from case_id (e.g. "ragtruth_24") to
-            source document text. Used to compute the content hash.
-            Multiple case_ids can share the same source text — dedup
-            happens automatically via the hash.
+            source document text. Every key here must have a
+            corresponding entry in the Exp 31 file when ``strict=True``.
+        strict: If True, raise ``FactTableValidationError`` when any
+            case_id in ``source_texts`` has no Exp 31 fact table.
+            Callers running a benchmark whose subset partially overlaps
+            Exp 31 (e.g., RAGTruth-50) should pass ``strict=False`` and
+            route failed case_ids to live extraction.
 
     Returns:
-        Summary dict with seeded_sources, skipped (no source text),
-        and dedup count.
+        ``{"seeded": int, "failed": list[str], "dedup_savings": int,
+           "exp31_cases_not_in_source_texts": list[str]}``.
+
+        - ``seeded``: count of unique source_hashes written to cache.
+        - ``failed``: case_ids present in ``source_texts`` with no Exp 31
+          entry. Non-empty + strict ⇒ raises.
+        - ``dedup_savings``: source_texts case_ids that mapped to an
+          already-seeded hash (siblings sharing a source).
+        - ``exp31_cases_not_in_source_texts``: reverse-direction drift —
+          Exp 31 case_ids the caller did not declare. Informational.
+
+    Raises:
+        FactTableValidationError: if ``strict`` and ``failed`` is non-empty.
+        FileNotFoundError: if ``exp31_path`` does not exist.
     """
     exp31_path = Path(exp31_path)
     if not exp31_path.exists():
-        logger.warning(
-            "preseed.file_not_found",
-            extra={"path": str(exp31_path)},
-        )
-        return {"error": f"file not found: {exp31_path}"}
+        raise FileNotFoundError(f"Exp 31 fact tables not found: {exp31_path}")
 
     data = json.loads(exp31_path.read_text(encoding="utf-8"))
 
     seeded_hashes: set[str] = set()
-    skipped: list[str] = []
+    failed: list[str] = []
+    dedup_savings = 0
 
-    for case_id, tables in data.items():
-        source_text = source_texts.get(case_id)
-        if source_text is None:
-            skipped.append(case_id)
+    for case_id, source_text in source_texts.items():
+        tables = data.get(case_id)
+        if tables is None:
+            failed.append(case_id)
             continue
 
         source_hash = compute_source_hash(source_text)
         if source_hash in seeded_hashes:
-            continue  # Already seeded from a sibling case
+            dedup_savings += 1
+            continue
 
-        # Store the passes (not the wrapper with source_len/pass_times)
         fact_data = {"passes": tables.get("passes", tables)}
         cache.put_by_hash(source_hash, fact_data)
         seeded_hashes.add(source_hash)
 
-    result = {
-        "total_cases": len(data),
-        "unique_sources_seeded": len(seeded_hashes),
-        "skipped_no_source_text": len(skipped),
-        "dedup_savings": len(data) - len(seeded_hashes) - len(skipped),
+    drift_cases = [cid for cid in data.keys() if cid not in source_texts]
+
+    result: dict[str, Any] = {
+        "seeded": len(seeded_hashes),
+        "failed": failed,
+        "dedup_savings": dedup_savings,
+        "exp31_cases_not_in_source_texts": drift_cases,
     }
 
-    logger.info("preseed.complete", extra=result)
+    if failed:
+        logger.warning(
+            "preseed.incomplete_coverage",
+            extra={
+                "failed_count": len(failed),
+                "failed_sample": failed[:5],
+                "seeded": len(seeded_hashes),
+                "strict": strict,
+            },
+        )
+        if strict:
+            raise FactTableValidationError(
+                f"preseed missing fact tables for {len(failed)} case_id(s) "
+                f"declared in source_texts. sample={failed[:5]}. "
+                f"exp31_path={exp31_path}. "
+                f"Set strict=False to accept partial coverage, or populate "
+                f"fact tables for the listed case_ids."
+            )
+    else:
+        logger.info("preseed.complete", extra={"seeded": len(seeded_hashes)})
+
     return result
 
 

--- a/tests/unit/test_graph_cache.py
+++ b/tests/unit/test_graph_cache.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from llm_judge.calibration.graph_cache import (
+    FactTableValidationError,
     GraphCache,
     compute_source_hash,
     get_graph_cache,
@@ -227,7 +228,6 @@ class TestClear:
 
 class TestPreseedFromExp31:
     def test_preseed_basic(self, cache: GraphCache, tmp_path: Path) -> None:
-        # Create a minimal Exp 31 file
         exp31_data = {
             "ragtruth_24": {
                 "source_len": 100,
@@ -249,43 +249,20 @@ class TestPreseedFromExp31:
         exp31_path = tmp_path / "exp31.json"
         exp31_path.write_text(json.dumps(exp31_data))
 
-        # Same source text for both cases (dedup test)
         source_texts = {
             "ragtruth_24": "Same source document.",
             "ragtruth_25": "Same source document.",
         }
 
         result = preseed_from_exp31(cache, exp31_path, source_texts)
-        assert result["total_cases"] == 2
-        assert result["unique_sources_seeded"] == 1  # deduped
+        assert result["seeded"] == 1  # dedup
         assert result["dedup_savings"] == 1
-        assert result["skipped_no_source_text"] == 0
-
-    def test_preseed_skips_missing_sources(
-        self, cache: GraphCache, tmp_path: Path
-    ) -> None:
-        exp31_data = {
-            "ragtruth_24": {"passes": {"P1_entities": {}}},
-            "ragtruth_25": {"passes": {"P1_entities": {}}},
-        }
-        exp31_path = tmp_path / "exp31.json"
-        exp31_path.write_text(json.dumps(exp31_data))
-
-        # Only provide source for one case
-        source_texts = {"ragtruth_24": "Some text."}
-
-        result = preseed_from_exp31(cache, exp31_path, source_texts)
-        assert result["unique_sources_seeded"] == 1
-        assert result["skipped_no_source_text"] == 1
-
-    def test_preseed_file_not_found(self, cache: GraphCache) -> None:
-        result = preseed_from_exp31(cache, "/nonexistent.json", {})
-        assert "error" in result
+        assert result["failed"] == []
+        assert result["exp31_cases_not_in_source_texts"] == []
 
     def test_preseed_data_retrievable(
         self, cache: GraphCache, tmp_path: Path
     ) -> None:
-        """After pre-seeding, cache.get returns the stored fact tables."""
         source_text = "Unique source document for retrieval test."
         exp31_data = {
             "case_1": {
@@ -300,6 +277,82 @@ class TestPreseedFromExp31:
         result = cache.get(source_text)
         assert result is not None
         assert result["passes"]["P1_entities"]["entities"][0]["name"] == "Test"
+
+    # Silence contract (#180): partial-coverage misses must surface.
+
+    def test_missing_fact_table_listed_in_failed(
+        self, cache: GraphCache, tmp_path: Path
+    ) -> None:
+        """case_ids declared by the caller but absent from Exp 31 → failed list."""
+        exp31_data = {"ragtruth_24": {"passes": {"P1_entities": {}}}}
+        exp31_path = tmp_path / "exp31.json"
+        exp31_path.write_text(json.dumps(exp31_data))
+
+        # Caller declares two cases; Exp 31 has one.
+        source_texts = {"ragtruth_24": "a", "ragtruth_99": "b"}
+
+        result = preseed_from_exp31(cache, exp31_path, source_texts)
+        assert result["seeded"] == 1
+        assert result["failed"] == ["ragtruth_99"]
+
+    def test_strict_raises_on_any_miss(
+        self, cache: GraphCache, tmp_path: Path
+    ) -> None:
+        """With strict=True, any miss raises with actionable detail."""
+        exp31_data = {"ragtruth_24": {"passes": {"P1_entities": {}}}}
+        exp31_path = tmp_path / "exp31.json"
+        exp31_path.write_text(json.dumps(exp31_data))
+
+        source_texts = {"ragtruth_24": "a", "ragtruth_99": "b"}
+
+        with pytest.raises(FactTableValidationError) as exc_info:
+            preseed_from_exp31(cache, exp31_path, source_texts, strict=True)
+        msg = str(exc_info.value)
+        assert "ragtruth_99" in msg
+        assert "1 case_id" in msg
+
+    def test_strict_passes_on_full_coverage(
+        self, cache: GraphCache, tmp_path: Path
+    ) -> None:
+        """strict=True is a no-op when every declared case has a fact table."""
+        exp31_data = {
+            "ragtruth_24": {"passes": {"P1_entities": {}}},
+            "ragtruth_25": {"passes": {"P1_entities": {}}},
+        }
+        exp31_path = tmp_path / "exp31.json"
+        exp31_path.write_text(json.dumps(exp31_data))
+
+        source_texts = {"ragtruth_24": "a", "ragtruth_25": "b"}
+
+        result = preseed_from_exp31(
+            cache, exp31_path, source_texts, strict=True
+        )
+        assert result["seeded"] == 2
+        assert result["failed"] == []
+
+    def test_drift_cases_reported_separately(
+        self, cache: GraphCache, tmp_path: Path
+    ) -> None:
+        """Exp 31 entries the caller didn't declare are informational drift,
+        not a failure."""
+        exp31_data = {
+            "ragtruth_24": {"passes": {"P1_entities": {}}},
+            "ragtruth_999": {"passes": {"P1_entities": {}}},  # not declared
+        }
+        exp31_path = tmp_path / "exp31.json"
+        exp31_path.write_text(json.dumps(exp31_data))
+
+        source_texts = {"ragtruth_24": "a"}
+
+        result = preseed_from_exp31(cache, exp31_path, source_texts)
+        assert result["seeded"] == 1
+        assert result["failed"] == []
+        assert result["exp31_cases_not_in_source_texts"] == ["ragtruth_999"]
+
+    def test_preseed_file_not_found_raises(self, cache: GraphCache) -> None:
+        """Missing Exp 31 file is a setup error; must be loud."""
+        with pytest.raises(FileNotFoundError):
+            preseed_from_exp31(cache, "/nonexistent.json", {})
 
 
 # =====================================================================

--- a/tests/unit/test_operator_scenario.py
+++ b/tests/unit/test_operator_scenario.py
@@ -55,7 +55,7 @@ class TestPreseedToCache:
         cache = GraphCache(tmp_path / "cache")
         result = preseed_from_exp31(cache, exp31_path, source_texts)
 
-        assert result["unique_sources_seeded"] == 1
+        assert result["seeded"] == 1
         assert result["dedup_savings"] == 1
 
         # Retrieve by source text

--- a/tools/run_ragtruth50.py
+++ b/tools/run_ragtruth50.py
@@ -90,12 +90,19 @@ def cmd_preseed(args: argparse.Namespace) -> bool:
     print(f"  Cache dir: {cache_dir}")
     print(f"  Source texts available: {len(source_texts)}")
 
-    result = preseed_from_exp31(cache, exp31_path, source_texts)
+    # RAGTruth-50 partially overlaps Exp 31's case set (#180). Accept
+    # partial coverage; the caller's benchmark runs live extraction for
+    # any case_id the preseed could not satisfy.
+    result = preseed_from_exp31(cache, exp31_path, source_texts, strict=False)
 
-    print(f"\n  Total cases in Exp 31:    {result.get('total_cases', '?')}")
-    print(f"  Unique sources seeded:    {result.get('unique_sources_seeded', '?')}")
+    failed = result.get("failed", [])
+    drift = result.get("exp31_cases_not_in_source_texts", [])
+    print(f"\n  Unique sources seeded:    {result.get('seeded', '?')}")
     print(f"  Dedup savings:            {result.get('dedup_savings', '?')}")
-    print(f"  Skipped (no source text): {result.get('skipped_no_source_text', '?')}")
+    print(f"  Preseed miss (no Exp 31): {len(failed)}")
+    if failed:
+        print(f"    sample: {failed[:5]}{'...' if len(failed) > 5 else ''}")
+    print(f"  Exp 31 drift (unused):    {len(drift)}")
     print(f"\n  Cache stats: {cache.stats()}")
     return True
 


### PR DESCRIPTION
## Summary

- `preseed_from_exp31` now iterates the caller's `source_texts` (declared case universe), not the Exp 31 file, so every miss surfaces by case_id.
- Returns `{seeded: int, failed: list[str], dedup_savings: int, exp31_cases_not_in_source_texts: list[str]}`. `strict=True` raises `FactTableValidationError` with actionable detail.
- RAGTruth-50 preseed honestly reports `seeded=2, failed=38, dedup=10` instead of silently skipping 38. (Bounded by the Exp 31 ∩ RAGTruth-50 source overlap of only 2 of 9 sources — see investigation.)

Closes #180.

## Investigation note

The original bug framing was "48 of 50 fail to match — key-scheme mismatch." Actual root cause is **subset mismatch**, not keys:

| | Exp 31 case_ids | RAGTruth-50 case_ids | Intersection |
|---|---|---|---|
| cases | 50 (ids 24..205 gaps) | 50 (ids 0..49) | **12** |
| unique source_ids | 9 | 9 | **2** |

Preseed iterates Exp 31's 50 case_ids, misses 38 that aren't in RAGTruth-50's declared universe. The 12 matches dedup by source_hash to 2 cache entries. That's the 2/50 symptom.

This PR fixes the silent-skip: failed case_ids are now enumerated, logged as `preseed.incomplete_coverage` WARNING, and raisable via `strict=True`. It does not attempt to close the 38-case coverage gap — that requires extracting fact tables for the 7 RAGTruth-50 sources Exp 31 doesn't cover (separate work).

Unblocks PR #182 parity visibility — cache-miss behavior is now observable.

## Test plan
- [x] Unit: 38 passing — 6 new silence-contract tests for strict-raise, failed-list, drift reporting, FileNotFoundError.
- [x] Integration: `python tools/run_ragtruth50.py preseed --cache-dir /tmp/preseed_180_verify` → prints `seeded=2, failed=38 (sample listed), dedup=10, drift=38`. Honest accounting.
- [x] Preflight PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)