### PR TITLE
Phase 1 (L1 completion): platform-as-harness verification flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@
         registry-list registry-show registry-trend eval preflight clean git-start git-ship git-merge validate \
         docker-build docker-deploy docker-status docker-validate docker-down docker-reset \
         preseed benchmark funnel calibrate demo \
-        demo-batch demo-batch-quick demo-batch-benchmark demo-batch-file
+        demo-batch demo-batch-quick demo-batch-benchmark demo-batch-file \
+        verify-l1
 
 # Defaults (override like: make SUITE=golden RUBRIC=chat_quality ...)
 SUITE ?= math_basic
@@ -29,6 +30,7 @@ help:
 	@echo "  make demo                  End-to-end Control Plane walkthrough"
 	@echo "  make demo-batch            Full RAGTruth-50 batch run (~7-10 min)"
 	@echo "  make demo-batch-quick      First 10 RAGTruth-50 cases (~1-2 min)"
+	@echo "  make verify-l1             Run L1-isolated batch + render verification report"
 	@echo "  make install               Install dependencies"
 	@echo "  make lint                  Run Ruff"
 	@echo "  make typecheck             Run mypy"
@@ -414,3 +416,24 @@ demo-batch-file:
 		exit 1; \
 	fi
 	@poetry run python tools/run_batch_evaluation.py --file $(FILE)
+
+# ----------------------------------------
+# Layer-by-layer verification (CAP-7)
+# ----------------------------------------
+# Each verify-LN target runs a standard batch with --isolate-layer LN
+# then renders a verification report against the layer's exit-criteria
+# spec. Verification reads only existing batch_run + single_eval
+# artifacts (platform-as-harness — no pipeline bypass).
+
+.PHONY: verify-l1
+
+verify-l1:
+	@poetry run python tools/run_batch_evaluation.py --benchmark ragtruth_50 --isolate-layer L1
+	@LATEST=$$(ls -1dt reports/batch_runs/batch-* | head -n 1) && \
+		poetry run python experiments/render_layer_verification_report.py \
+			--batch-run $$LATEST \
+			--layer L1 \
+			--target-detection 0.074 \
+			--tolerance-detection 0.005 \
+			--target-precision 1.0 \
+			--benchmark ragtruth_50

--- a/datasets/benchmarks/ragtruth/ragtruth_5_benchmark.json
+++ b/datasets/benchmarks/ragtruth/ragtruth_5_benchmark.json
@@ -1,0 +1,20 @@
+{
+  "benchmark_id": "ragtruth_5",
+  "version": "1.0",
+  "created": "2026-04-27",
+  "description": "5-response slice of RAGTruth (the first 5 response IDs of ragtruth_50). Used for fast integration tests of the platform-as-harness verification flow (--isolate-layer plumbing test in Phase 1; future per-layer integration tests in L2-L5).",
+  "source_file": "datasets/benchmarks/ragtruth/response.jsonl",
+  "response_ids": [
+    "0",
+    "1",
+    "2",
+    "3",
+    "4"
+  ],
+  "usage": "from llm_judge.benchmarks.registry import build; build('ragtruth_5')",
+  "rules": [
+    "Composes with ragtruth_50: response_ids is a strict prefix subset",
+    "Test-only — never compare F1 against published baselines on this slice",
+    "Add new IDs only if a verification test legitimately needs them"
+  ]
+}

--- a/experiments/render_layer_verification_report.py
+++ b/experiments/render_layer_verification_report.py
@@ -1,0 +1,825 @@
+"""Layer-by-layer verification report renderer (platform-as-harness).
+
+Reads the artifacts produced by a standard batch run invoked with
+``--isolate-layer <layer>`` and renders an HTML + Markdown verification
+report. **No platform bypass** — the renderer only consumes existing
+artifacts written by the Runner / CAP-5 path:
+
+  * ``<batch_run>/cases/<case_id>/manifest.json``  — envelope (proves
+    CAP-7 ran)
+  * ``<batch_run>/cases/<case_id>/events.jsonl``   — sub-capability
+    boundary events (proves L1 boundaries fired)
+  * ``<single_eval_root>/<case_id>/manifest.json`` — full CAP-5
+    manifest carrying ``verdict.layers_requested``,
+    ``verdict.layer_stats`` and ``verdict.sentence_results``
+
+Ground truth is loaded from the registered benchmark
+(e.g. ``ragtruth_50``); span annotations are aligned to the same
+sentence segmentation CAP-7 used (``_split_sentences`` from
+``llm_judge.calibration.hallucination``) so per-sentence labels line
+up with ``verdict.sentence_results[i].sentence_idx``.
+
+Verdict logic (PASS / FAIL / PARTIAL):
+  * FAIL    — precision below ``--target-precision``
+  * PASS    — precision ≥ target AND detection within tolerance
+  * PARTIAL — precision ≥ target AND detection outside tolerance
+              (algorithm still high-precision, but corpus/segmentation
+              shift moved the detection rate; surfaces for review)
+
+The renderer is parameterised by layer ID, target spec, and benchmark.
+L2-L5 verification will reuse this same script — only the CLI args
+change. The output is written under
+``reports/verifications/<layer>_<benchmark>_<timestamp>/``.
+
+Mirrors ``tools/_batch_html_report.py``'s rendering pattern: Rich
+``Console(record=True, force_terminal=True)`` + small ``_render_*``
+helpers + dual ``console.export_text(clear=False)`` /
+``console.export_html()`` export. No Jinja2.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from llm_judge.benchmarks import BenchmarkCase
+from llm_judge.benchmarks.registry import build
+from llm_judge.calibration.hallucination import _split_sentences
+
+
+# Replicated from tools/_batch_html_report.py to avoid importing through
+# tools/run_batch_evaluation.py's sys.path shim. If a third verification
+# renderer ever needs the same constants, factor out a helpers module.
+_RAG_STYLES = {
+    "green": "[green]●[/green] green",
+    "amber": "[yellow]●[/yellow] amber",
+    "red": "[red]●[/red] red",
+}
+
+
+def _utc_now_iso() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+@dataclass
+class CaseEvidence:
+    """Per-case evidence assembled from the three artifact sources."""
+
+    case_id: str
+    response_text: str
+    sentence_count: int
+    layers_requested: list[str]
+    layer_stats: dict[str, int | float]
+    cleared_indices: set[int]
+    sub_capability_events: list[dict[str, Any]]
+    span_annotations: list[dict[str, Any]]
+
+
+@dataclass
+class CaseClassification:
+    """Per-case TP/FP/TN/FN counts (sentence-level)."""
+
+    case_id: str
+    sentence_count: int
+    tp: int
+    fp: int
+    tn: int
+    fn: int
+
+    @property
+    def cleared(self) -> int:
+        return self.tp + self.fp
+
+
+@dataclass
+class VerificationMetrics:
+    """Aggregated metrics across all cases."""
+
+    total_sentences: int
+    total_responses: int
+    tp: int
+    fp: int
+    tn: int
+    fn: int
+    detection_rate: float
+    precision: float
+    recall: float
+    f1: float
+
+
+def _load_benchmark_cases(benchmark: str) -> dict[str, BenchmarkCase]:
+    """Load benchmark cases keyed by case_id (== response id used by the
+    batch driver). Allows O(1) ground-truth lookup per batch case."""
+    adapter = build(benchmark)
+    cases: dict[str, BenchmarkCase] = {}
+    case_iter: Iterator[BenchmarkCase] = adapter.load_cases()
+    for case in case_iter:
+        cases[case.case_id] = case
+    return cases
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Read a JSONL file and return a list of dicts (empty if missing)."""
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            rows.append(json.loads(line))
+    return rows
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _gather_case_evidence(
+    *,
+    case_id: str,
+    batch_run_dir: Path,
+    single_eval_root: Path,
+    benchmark_case: BenchmarkCase,
+) -> CaseEvidence:
+    """Assemble per-case evidence from batch_run + single_eval artifacts.
+
+    Surfaces a ``ValueError`` with a concrete artifact path on missing
+    fields rather than silently coercing — surprising data shapes should
+    fail loud, not produce a report with hidden zeros.
+    """
+    case_dir = batch_run_dir / "cases" / case_id
+    events_path = case_dir / "events.jsonl"
+    sub_cap_events = [
+        e
+        for e in _read_jsonl(events_path)
+        if e.get("event", "").startswith("sub_capability_")
+    ]
+
+    cap5_manifest_path = single_eval_root / case_id / "manifest.json"
+    if not cap5_manifest_path.exists():
+        raise FileNotFoundError(
+            f"renderer: CAP-5 manifest missing at {cap5_manifest_path}; "
+            f"the renderer needs verdict data from the single_eval store. "
+            f"Was this batch run with case_id={case_id!r}?"
+        )
+    manifest = _read_json(cap5_manifest_path)
+    verdict = manifest.get("verdict", {})
+    layer_stats = dict(verdict.get("layer_stats", {}))
+    layers_requested = list(verdict.get("layers_requested", []))
+    sentence_results = list(verdict.get("sentence_results", []))
+
+    if "total_sentences" not in layer_stats:
+        raise ValueError(
+            f"renderer: verdict.layer_stats missing 'total_sentences' "
+            f"in {cap5_manifest_path}; refresh the batch run after the "
+            f"CAP-7 wrapper change that surfaces total_sentences."
+        )
+    sentence_count = int(layer_stats["total_sentences"])
+
+    cleared_indices = {
+        int(sr["sentence_idx"])
+        for sr in sentence_results
+        if sr.get("resolved_by") == "L1"
+    }
+
+    response_text = benchmark_case.request.candidate_answer
+    span_annotations = [
+        {
+            "start": ann.start,
+            "end": ann.end,
+            "text": ann.text,
+            "label_type": ann.label_type,
+        }
+        for ann in benchmark_case.ground_truth.span_annotations
+    ]
+
+    return CaseEvidence(
+        case_id=case_id,
+        response_text=response_text,
+        sentence_count=sentence_count,
+        layers_requested=layers_requested,
+        layer_stats=layer_stats,
+        cleared_indices=cleared_indices,
+        sub_capability_events=sub_cap_events,
+        span_annotations=span_annotations,
+    )
+
+
+def _classify_case(evidence: CaseEvidence) -> CaseClassification:
+    """Compute sentence-level confusion matrix for a single case.
+
+    A sentence is *grounded* when no ground-truth span overlaps it; a
+    sentence is *cleared* when it appears in
+    ``verdict.sentence_results`` with ``resolved_by == "L1"``. The four
+    quadrants follow:
+
+      TP — cleared & grounded     (L1 correctly cleared)
+      FP — cleared & ungrounded   (L1 incorrectly cleared) → precision-killer
+      TN — uncleared & ungrounded (L1 correctly let the cascade through)
+      FN — uncleared & grounded   (L1 missed an easy one)
+
+    Sentence segmentation matches CAP-7 by reusing
+    ``_split_sentences``; alignment is positional (sentence_idx ↔ list
+    index from spaCy doc.sents with the same length filter).
+    """
+    sents = _split_sentences(evidence.response_text)
+    if len(sents) != evidence.sentence_count:
+        # Loud failure: sentence-segmentation drift between CAP-7 run
+        # time and renderer would silently miscount the matrix. If this
+        # ever fires, the response_text we read from the benchmark
+        # adapter has been mutated since the batch run, or spaCy
+        # version-skewed mid-run.
+        raise ValueError(
+            f"renderer: sentence-count mismatch for {evidence.case_id} — "
+            f"manifest says {evidence.sentence_count}, "
+            f"renderer split returns {len(sents)}. Re-run the batch "
+            f"after pinning spaCy / model version."
+        )
+
+    # Per-sentence ground-truth labels via span containment.
+    # ``span.text`` is the verbatim hallucinated substring; if it
+    # appears in a sentence, that sentence is ungrounded. Char offsets
+    # are not required because the registered RAGTruth annotations
+    # already carry the offending text.
+    span_texts = [s["text"] for s in evidence.span_annotations if s["text"]]
+    ungrounded_idx: set[int] = set()
+    for i, sent in enumerate(sents):
+        if any(span and span in sent for span in span_texts):
+            ungrounded_idx.add(i)
+
+    tp = fp = tn = fn = 0
+    for i in range(evidence.sentence_count):
+        cleared = i in evidence.cleared_indices
+        ungrounded = i in ungrounded_idx
+        if cleared and not ungrounded:
+            tp += 1
+        elif cleared and ungrounded:
+            fp += 1
+        elif not cleared and ungrounded:
+            tn += 1
+        else:
+            fn += 1
+
+    return CaseClassification(
+        case_id=evidence.case_id,
+        sentence_count=evidence.sentence_count,
+        tp=tp,
+        fp=fp,
+        tn=tn,
+        fn=fn,
+    )
+
+
+def _aggregate_metrics(
+    classifications: list[CaseClassification],
+) -> VerificationMetrics:
+    """Sum per-case quadrants and compute detection / precision / recall / F1."""
+    tp = sum(c.tp for c in classifications)
+    fp = sum(c.fp for c in classifications)
+    tn = sum(c.tn for c in classifications)
+    fn = sum(c.fn for c in classifications)
+    total = tp + fp + tn + fn
+
+    detection_rate = (tp + fp) / total if total else 0.0
+    precision = tp / (tp + fp) if (tp + fp) else 0.0
+    recall = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = (
+        2 * precision * recall / (precision + recall)
+        if (precision + recall)
+        else 0.0
+    )
+
+    return VerificationMetrics(
+        total_sentences=total,
+        total_responses=len(classifications),
+        tp=tp,
+        fp=fp,
+        tn=tn,
+        fn=fn,
+        detection_rate=detection_rate,
+        precision=precision,
+        recall=recall,
+        f1=f1,
+    )
+
+
+def _compute_verdict(
+    metrics: VerificationMetrics,
+    *,
+    target_detection: float,
+    tolerance_detection: float,
+    target_precision: float,
+) -> tuple[str, list[str]]:
+    """Return ``(verdict, findings)``.
+
+    Findings is an ordered list of human-readable lines suitable for
+    inclusion in the report's findings panel.
+    """
+    findings: list[str] = []
+    detection_low = target_detection - tolerance_detection
+    detection_high = target_detection + tolerance_detection
+    detection_in_tolerance = detection_low <= metrics.detection_rate <= detection_high
+    precision_at_target = metrics.precision >= target_precision
+
+    if not precision_at_target:
+        verdict = "FAIL"
+        findings.append(
+            f"Precision {metrics.precision:.4f} below target "
+            f"{target_precision:.4f} — L1 cleared {metrics.fp} sentence(s) "
+            f"that contain hallucination spans (false positives)."
+        )
+    elif detection_in_tolerance:
+        verdict = "PASS"
+        findings.append(
+            f"Precision {metrics.precision:.4f} ≥ target "
+            f"{target_precision:.4f} — every L1-cleared sentence is "
+            f"correctly grounded ({metrics.tp} TP, 0 FP)."
+        )
+        findings.append(
+            f"Detection rate {metrics.detection_rate:.4f} within "
+            f"tolerance [{detection_low:.4f}, {detection_high:.4f}]."
+        )
+    else:
+        verdict = "PARTIAL"
+        findings.append(
+            f"Precision {metrics.precision:.4f} ≥ target "
+            f"{target_precision:.4f} (algorithm still high-precision)."
+        )
+        findings.append(
+            f"Detection rate {metrics.detection_rate:.4f} OUTSIDE "
+            f"tolerance [{detection_low:.4f}, {detection_high:.4f}] — "
+            f"corpus / segmentation shift, NOT an algorithm failure. "
+            f"Investigate before promoting."
+        )
+    return verdict, findings
+
+
+# ----------------------------------------------------------------------
+# Rendering — Rich Console pattern, mirrors tools/_batch_html_report.py
+# ----------------------------------------------------------------------
+
+
+def _render_header(
+    console: Console,
+    *,
+    layer: str,
+    benchmark: str,
+    batch_run_dir: Path,
+    output_dir: Path,
+    verdict: str,
+) -> None:
+    verdict_color = {"PASS": "green", "FAIL": "red", "PARTIAL": "yellow"}[verdict]
+    body = (
+        f"[bold]layer[/bold]         {layer}\n"
+        f"[bold]benchmark[/bold]     {benchmark}\n"
+        f"[bold]batch_run[/bold]     {batch_run_dir}\n"
+        f"[bold]rendered_at[/bold]   {_utc_now_iso()}\n"
+        f"[bold]output_dir[/bold]    {output_dir}\n"
+        f"[bold]verdict[/bold]       [{verdict_color}]{verdict}[/{verdict_color}]"
+    )
+    console.print(Panel(body, title="Layer verification report", style="cyan"))
+
+
+def _render_summary(
+    console: Console,
+    metrics: VerificationMetrics,
+    *,
+    target_detection: float,
+    tolerance_detection: float,
+    target_precision: float,
+) -> None:
+    detection_low = target_detection - tolerance_detection
+    detection_high = target_detection + tolerance_detection
+    detection_in_tolerance = detection_low <= metrics.detection_rate <= detection_high
+    precision_at_target = metrics.precision >= target_precision
+
+    detection_label = (
+        f"[green]{metrics.detection_rate:.4f}[/green]"
+        if detection_in_tolerance
+        else f"[yellow]{metrics.detection_rate:.4f}[/yellow]"
+    )
+    precision_label = (
+        f"[green]{metrics.precision:.4f}[/green]"
+        if precision_at_target
+        else f"[red]{metrics.precision:.4f}[/red]"
+    )
+
+    table = Table(
+        title="Verification summary",
+        show_header=True,
+        header_style="bold magenta",
+    )
+    table.add_column("Metric")
+    table.add_column("Value", justify="right")
+    table.add_column("Target", justify="right")
+    table.add_column("Status")
+
+    table.add_row(
+        "Detection rate",
+        detection_label,
+        f"{target_detection:.4f} ± {tolerance_detection:.4f}",
+        _RAG_STYLES["green"] if detection_in_tolerance else _RAG_STYLES["amber"],
+    )
+    table.add_row(
+        "Precision",
+        precision_label,
+        f"≥ {target_precision:.4f}",
+        _RAG_STYLES["green"] if precision_at_target else _RAG_STYLES["red"],
+    )
+    table.add_row("Recall", f"{metrics.recall:.4f}", "—", "[dim]informational[/dim]")
+    table.add_row("F1", f"{metrics.f1:.4f}", "—", "[dim]informational[/dim]")
+    console.print(table)
+
+
+def _render_metrics_detail(
+    console: Console, metrics: VerificationMetrics
+) -> None:
+    body = (
+        f"[bold]TP[/bold]               {metrics.tp}\n"
+        f"[bold]FP[/bold]               {metrics.fp}\n"
+        f"[bold]TN[/bold]               {metrics.tn}\n"
+        f"[bold]FN[/bold]               {metrics.fn}\n"
+        f"[bold]total_sentences[/bold]  {metrics.total_sentences}\n"
+        f"[bold]total_responses[/bold]  {metrics.total_responses}"
+    )
+    console.print(Panel(body, title="Sentence-level confusion matrix", style="blue"))
+
+
+def _render_per_case_attribution(
+    console: Console, classifications: list[CaseClassification]
+) -> None:
+    if not classifications:
+        console.print("[dim](no cases)[/dim]")
+        return
+    table = Table(
+        title="Per-case attribution",
+        show_header=True,
+        header_style="bold magenta",
+    )
+    table.add_column("case_id")
+    table.add_column("sentences", justify="right")
+    table.add_column("L1 cleared", justify="right")
+    table.add_column("TP", justify="right")
+    table.add_column("FP", justify="right")
+    table.add_column("TN", justify="right")
+    table.add_column("FN", justify="right")
+    for c in classifications:
+        fp_label = (
+            f"[red]{c.fp}[/red]" if c.fp > 0 else "[dim]0[/dim]"
+        )
+        table.add_row(
+            c.case_id,
+            str(c.sentence_count),
+            str(c.cleared),
+            str(c.tp),
+            fp_label,
+            str(c.tn),
+            str(c.fn),
+        )
+    console.print(table)
+
+
+def _render_subcap_events(
+    console: Console,
+    layer: str,
+    sample_evidence: CaseEvidence | None,
+    boundary_summary: dict[str, Counter[str]],
+) -> None:
+    """Show CAP-7 sub-capability boundary firing across the run.
+
+    The summary is ``{sub_capability_id: Counter({event_type: n, ...})}``
+    aggregated across cases — flat enough for L1's four boundaries today,
+    extends naturally to L2-L5 instrumentation as it lands.
+    """
+    if not boundary_summary:
+        console.print(
+            Panel(
+                f"No CAP-7 sub-capability events captured for layer {layer}. "
+                f"Either the run did not exercise this layer, or the "
+                f"layer is not yet instrumented (sub-capability "
+                f"instrumentation rolls out level-by-level).",
+                title="Sub-capability events",
+                style="yellow",
+            )
+        )
+        return
+    table = Table(
+        title=f"{layer} sub-capability boundary events (across {len(boundary_summary)} boundaries)",
+        show_header=True,
+        header_style="bold cyan",
+    )
+    table.add_column("sub_capability_id")
+    table.add_column("started", justify="right")
+    table.add_column("completed", justify="right")
+    table.add_column("skipped", justify="right")
+    table.add_column("typical reason / status")
+    for sub_id, counter in sorted(boundary_summary.items()):
+        started = counter.get("sub_capability_started", 0)
+        completed = counter.get("sub_capability_completed", 0)
+        skipped = counter.get("sub_capability_skipped", 0)
+        # Pull a representative reason from the sample case (helps the
+        # reader see WHY a SOFT boundary skipped without dumping every
+        # event).
+        reason = ""
+        if sample_evidence is not None:
+            for ev in sample_evidence.sub_capability_events:
+                if ev.get("sub_capability_id") == sub_id:
+                    if ev.get("event") == "sub_capability_skipped":
+                        reason = f"skipped: {ev.get('reason', '')[:60]}"
+                        break
+                    if ev.get("event") == "sub_capability_completed":
+                        reason = f"completed ({ev.get('status', 'success')})"
+                        break
+        table.add_row(
+            sub_id,
+            str(started),
+            str(completed),
+            str(skipped),
+            reason,
+        )
+    console.print(table)
+
+
+def _render_findings(console: Console, verdict: str, findings: list[str]) -> None:
+    style = {"PASS": "green", "FAIL": "red", "PARTIAL": "yellow"}[verdict]
+    body = "\n".join(f"• {line}" for line in findings) if findings else "(none)"
+    console.print(Panel(body, title=f"Findings — {verdict}", style=style))
+
+
+def _render_provenance(
+    console: Console,
+    *,
+    batch_run_dir: Path,
+    single_eval_root: Path,
+    layer: str,
+    benchmark: str,
+) -> None:
+    body = (
+        f"[bold]layer[/bold]            {layer}\n"
+        f"[bold]benchmark[/bold]        {benchmark}\n"
+        f"[bold]batch_run_dir[/bold]    {batch_run_dir}\n"
+        f"[bold]single_eval_root[/bold] {single_eval_root}\n"
+        f"[bold]rendered_at[/bold]      {_utc_now_iso()}"
+    )
+    console.print(Panel(body, title="Provenance", style="blue"))
+
+
+def render_verification_report(
+    *,
+    batch_run_dir: Path,
+    single_eval_root: Path,
+    benchmark: str,
+    layer: str,
+    target_detection: float,
+    tolerance_detection: float,
+    target_precision: float,
+    output_dir: Path,
+) -> str:
+    """Render the verification report and return the verdict."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    case_dirs = sorted(
+        d for d in (batch_run_dir / "cases").iterdir() if d.is_dir()
+    )
+    if not case_dirs:
+        raise ValueError(
+            f"renderer: no cases under {batch_run_dir / 'cases'}; "
+            f"is this a completed batch run?"
+        )
+    case_ids = [d.name for d in case_dirs]
+
+    benchmark_cases = _load_benchmark_cases(benchmark)
+    missing = [cid for cid in case_ids if cid not in benchmark_cases]
+    if missing:
+        raise ValueError(
+            f"renderer: case_id(s) {missing[:5]} present in batch_run "
+            f"but not in benchmark {benchmark!r}. Mismatched batch / "
+            f"benchmark pair."
+        )
+
+    evidence_list: list[CaseEvidence] = []
+    for cid in case_ids:
+        evidence_list.append(
+            _gather_case_evidence(
+                case_id=cid,
+                batch_run_dir=batch_run_dir,
+                single_eval_root=single_eval_root,
+                benchmark_case=benchmark_cases[cid],
+            )
+        )
+
+    classifications = [_classify_case(e) for e in evidence_list]
+    metrics = _aggregate_metrics(classifications)
+    verdict, findings = _compute_verdict(
+        metrics,
+        target_detection=target_detection,
+        tolerance_detection=tolerance_detection,
+        target_precision=target_precision,
+    )
+
+    boundary_summary: dict[str, Counter[str]] = {}
+    for ev in evidence_list:
+        for event in ev.sub_capability_events:
+            sub_id = event.get("sub_capability_id", "")
+            ev_type = event.get("event", "")
+            if not sub_id:
+                continue
+            if sub_id not in boundary_summary:
+                boundary_summary[sub_id] = Counter()
+            boundary_summary[sub_id][ev_type] += 1
+    sample_evidence = evidence_list[0] if evidence_list else None
+
+    console = Console(record=True, force_terminal=True)
+    console.print()
+    _render_header(
+        console,
+        layer=layer,
+        benchmark=benchmark,
+        batch_run_dir=batch_run_dir,
+        output_dir=output_dir,
+        verdict=verdict,
+    )
+    _render_summary(
+        console,
+        metrics,
+        target_detection=target_detection,
+        tolerance_detection=tolerance_detection,
+        target_precision=target_precision,
+    )
+    _render_metrics_detail(console, metrics)
+    _render_per_case_attribution(console, classifications)
+    _render_subcap_events(console, layer, sample_evidence, boundary_summary)
+    _render_findings(console, verdict, findings)
+    _render_provenance(
+        console,
+        batch_run_dir=batch_run_dir,
+        single_eval_root=single_eval_root,
+        layer=layer,
+        benchmark=benchmark,
+    )
+
+    md_path = output_dir / "verification_report.md"
+    html_path = output_dir / "verification_report.html"
+    md_path.write_text(console.export_text(clear=False), encoding="utf-8")
+    html_path.write_text(console.export_html(), encoding="utf-8")
+
+    summary_path = output_dir / "verification_summary.json"
+    summary_path.write_text(
+        json.dumps(
+            {
+                "layer": layer,
+                "benchmark": benchmark,
+                "verdict": verdict,
+                "metrics": {
+                    "detection_rate": metrics.detection_rate,
+                    "precision": metrics.precision,
+                    "recall": metrics.recall,
+                    "f1": metrics.f1,
+                    "tp": metrics.tp,
+                    "fp": metrics.fp,
+                    "tn": metrics.tn,
+                    "fn": metrics.fn,
+                    "total_sentences": metrics.total_sentences,
+                    "total_responses": metrics.total_responses,
+                },
+                "targets": {
+                    "detection": target_detection,
+                    "tolerance": tolerance_detection,
+                    "precision": target_precision,
+                },
+                "findings": findings,
+                "batch_run_dir": str(batch_run_dir),
+                "single_eval_root": str(single_eval_root),
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    return verdict
+
+
+def _build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Render a layer-by-layer verification report from an existing "
+            "batch run. Reads only existing artifacts — does not re-invoke "
+            "the hallucination pipeline (platform-as-harness)."
+        )
+    )
+    parser.add_argument(
+        "--batch-run",
+        type=Path,
+        required=True,
+        help="Path to a completed batch run directory (reports/batch_runs/<id>).",
+    )
+    parser.add_argument(
+        "--layer",
+        type=str,
+        required=True,
+        choices=["L1", "L2", "L3", "L4", "L5"],
+        help="Which CAP-7 layer this run isolated.",
+    )
+    parser.add_argument(
+        "--target-detection",
+        type=float,
+        required=True,
+        help="Target detection rate (e.g. 0.074 for L1's 7.4% target).",
+    )
+    parser.add_argument(
+        "--tolerance-detection",
+        type=float,
+        required=True,
+        help="Two-sided tolerance for detection rate (e.g. 0.005 for ±0.5pp).",
+    )
+    parser.add_argument(
+        "--target-precision",
+        type=float,
+        required=True,
+        help="Minimum acceptable precision (e.g. 1.0 for L1's 100% target).",
+    )
+    parser.add_argument(
+        "--benchmark",
+        type=str,
+        required=True,
+        help="Registered benchmark name for ground-truth lookup (e.g. ragtruth_50).",
+    )
+    parser.add_argument(
+        "--single-eval-root",
+        type=Path,
+        default=Path("reports/single_eval"),
+        help=(
+            "Root directory where CAP-5 manifests live "
+            "(default: reports/single_eval). Each case_id reads its "
+            "verdict from <single-eval-root>/<case_id>/manifest.json."
+        ),
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Output directory (default: "
+            "reports/verifications/<layer>_<benchmark>_<UTC-timestamp>/)."
+        ),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_argparser().parse_args(argv)
+
+    batch_run_dir = args.batch_run.resolve()
+    if not batch_run_dir.is_dir():
+        print(f"error: batch_run {batch_run_dir} is not a directory", file=sys.stderr)
+        return 2
+
+    output_dir = args.output_dir
+    if output_dir is None:
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H%M%S")
+        output_dir = Path("reports/verifications") / (
+            f"{args.layer.lower()}_{args.benchmark}_{ts}"
+        )
+
+    try:
+        verdict = render_verification_report(
+            batch_run_dir=batch_run_dir,
+            single_eval_root=args.single_eval_root,
+            benchmark=args.benchmark,
+            layer=args.layer,
+            target_detection=args.target_detection,
+            tolerance_detection=args.tolerance_detection,
+            target_precision=args.target_precision,
+            output_dir=output_dir,
+        )
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"renderer failed: {exc}", file=sys.stderr)
+        return 1
+
+    print()
+    print(f"output: {output_dir}/")
+    print(f"verdict: {verdict}")
+    print(f"report: {output_dir / 'verification_report.html'}")
+    return 0 if verdict in ("PASS", "PARTIAL") else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/render_layer_verification_report.py
+++ b/experiments/render_layer_verification_report.py
@@ -90,6 +90,43 @@ class CaseEvidence:
     span_annotations: list[dict[str, Any]]
 
 
+# Three states a case can land in for the verification flow.
+#  * "success"             — CAP-1/2/7 all succeeded, verdict is valid;
+#                            included in the metrics aggregation.
+#  * "platform_fault"      — CAP-1 or CAP-2 (or both) failed before
+#                            CAP-7 ran (or CAP-7 itself errored).
+#                            Excluded from metrics. Surfaced in the
+#                            Platform Faults panel — NOT silently
+#                            dropped.
+#  * "l1_verdict_missing"  — CAP-7 ran but produced no usable L1
+#                            verdict (e.g. the manifest is shaped from
+#                            an older run that predates the
+#                            sentence_results / total_sentences
+#                            surfacing change). Also excluded;
+#                            distinguished from platform_fault because
+#                            the cause is renderer / wrapper plumbing,
+#                            not the upstream platform.
+CASE_STATE_SUCCESS = "success"
+CASE_STATE_PLATFORM_FAULT = "platform_fault"
+CASE_STATE_L1_VERDICT_MISSING = "l1_verdict_missing"
+
+
+@dataclass
+class CaseDisposition:
+    """Per-case outcome at the verification layer.
+
+    ``state`` is one of the ``CASE_STATE_*`` constants. ``evidence`` is
+    populated for ``success`` cases and is ``None`` otherwise. ``reason``
+    is a short human-readable string suitable for the Platform Faults
+    panel.
+    """
+
+    case_id: str
+    state: str
+    reason: str
+    evidence: CaseEvidence | None = None
+
+
 @dataclass
 class CaseClassification:
     """Per-case TP/FP/TN/FN counts (sentence-level)."""
@@ -152,33 +189,76 @@ def _read_json(path: Path) -> dict[str, Any]:
         return json.load(f)
 
 
-def _gather_case_evidence(
+def _classify_disposition(
     *,
     case_id: str,
     batch_run_dir: Path,
     single_eval_root: Path,
     benchmark_case: BenchmarkCase,
-) -> CaseEvidence:
-    """Assemble per-case evidence from batch_run + single_eval artifacts.
+) -> CaseDisposition:
+    """Classify a case into success / platform_fault / l1_verdict_missing.
 
-    Surfaces a ``ValueError`` with a concrete artifact path on missing
-    fields rather than silently coercing — surprising data shapes should
-    fail loud, not produce a report with hidden zeros.
+    The decision walks the per-case batch envelope first (cheapest
+    signal — captures CAP-1/2/7 status without parsing the verdict),
+    then the CAP-5 manifest (for verdict shape). A platform fault
+    short-circuits before any verdict parsing.
     """
     case_dir = batch_run_dir / "cases" / case_id
     events_path = case_dir / "events.jsonl"
+    envelope_path = case_dir / "manifest.json"
     sub_cap_events = [
         e
         for e in _read_jsonl(events_path)
         if e.get("event", "").startswith("sub_capability_")
     ]
 
+    # Walk the per-case envelope first. Its ``integrity[]`` records the
+    # status of every capability that ran (or was skipped upstream).
+    if not envelope_path.exists():
+        return CaseDisposition(
+            case_id=case_id,
+            state=CASE_STATE_PLATFORM_FAULT,
+            reason=f"per-case envelope missing at {envelope_path}",
+        )
+    envelope = _read_json(envelope_path)
+    integrity_records = envelope.get("integrity", [])
+    by_cap = {r.get("capability_id"): r for r in integrity_records}
+
+    # Platform fault: any of CAP-1, CAP-2, CAP-7 didn't reach success.
+    # ``status`` values are "success", "failure", "skipped_upstream_failure".
+    # We treat anything other than "success" on these three caps as a
+    # fault (CAP-2 is in the list because a CAP-2 failure leaves CAP-7
+    # in an unclear state for verification).
+    for cap_id in ("CAP-1", "CAP-2", "CAP-7"):
+        record = by_cap.get(cap_id)
+        if record is None:
+            return CaseDisposition(
+                case_id=case_id,
+                state=CASE_STATE_PLATFORM_FAULT,
+                reason=f"{cap_id} missing from envelope.integrity",
+            )
+        status = record.get("status", "")
+        if status != "success":
+            err = record.get("error_type") or status
+            err_msg = (record.get("error_message") or "")[:120]
+            reason = f"{cap_id} status={status}"
+            if err and err != status:
+                reason += f" ({err})"
+            if err_msg:
+                reason += f": {err_msg}"
+            return CaseDisposition(
+                case_id=case_id,
+                state=CASE_STATE_PLATFORM_FAULT,
+                reason=reason,
+            )
+
+    # All caps green: read the CAP-5 manifest for the verdict.
     cap5_manifest_path = single_eval_root / case_id / "manifest.json"
     if not cap5_manifest_path.exists():
-        raise FileNotFoundError(
-            f"renderer: CAP-5 manifest missing at {cap5_manifest_path}; "
-            f"the renderer needs verdict data from the single_eval store. "
-            f"Was this batch run with case_id={case_id!r}?"
+        return CaseDisposition(
+            case_id=case_id,
+            state=CASE_STATE_L1_VERDICT_MISSING,
+            reason=f"CAP-5 manifest missing at {cap5_manifest_path}",
         )
     manifest = _read_json(cap5_manifest_path)
     verdict = manifest.get("verdict", {})
@@ -186,20 +266,28 @@ def _gather_case_evidence(
     layers_requested = list(verdict.get("layers_requested", []))
     sentence_results = list(verdict.get("sentence_results", []))
 
-    if "total_sentences" not in layer_stats:
-        raise ValueError(
-            f"renderer: verdict.layer_stats missing 'total_sentences' "
-            f"in {cap5_manifest_path}; refresh the batch run after the "
-            f"CAP-7 wrapper change that surfaces total_sentences."
+    if not verdict:
+        return CaseDisposition(
+            case_id=case_id,
+            state=CASE_STATE_L1_VERDICT_MISSING,
+            reason="CAP-5 manifest has empty verdict (likely written before CAP-7 succeeded)",
         )
-    sentence_count = int(layer_stats["total_sentences"])
+    if "total_sentences" not in layer_stats:
+        return CaseDisposition(
+            case_id=case_id,
+            state=CASE_STATE_L1_VERDICT_MISSING,
+            reason=(
+                "verdict.layer_stats missing 'total_sentences' — "
+                "manifest predates the CAP-7 wrapper change that surfaces it"
+            ),
+        )
 
+    sentence_count = int(layer_stats["total_sentences"])
     cleared_indices = {
         int(sr["sentence_idx"])
         for sr in sentence_results
         if sr.get("resolved_by") == "L1"
     }
-
     response_text = benchmark_case.request.candidate_answer
     span_annotations = [
         {
@@ -210,8 +298,7 @@ def _gather_case_evidence(
         }
         for ann in benchmark_case.ground_truth.span_annotations
     ]
-
-    return CaseEvidence(
+    evidence = CaseEvidence(
         case_id=case_id,
         response_text=response_text,
         sentence_count=sentence_count,
@@ -220,6 +307,12 @@ def _gather_case_evidence(
         cleared_indices=cleared_indices,
         sub_capability_events=sub_cap_events,
         span_annotations=span_annotations,
+    )
+    return CaseDisposition(
+        case_id=case_id,
+        state=CASE_STATE_SUCCESS,
+        reason="",
+        evidence=evidence,
     )
 
 
@@ -405,6 +498,9 @@ def _render_summary(
     target_detection: float,
     tolerance_detection: float,
     target_precision: float,
+    cases_included: int,
+    cases_total: int,
+    cases_excluded: int,
 ) -> None:
     detection_low = target_detection - tolerance_detection
     detection_high = target_detection + tolerance_detection
@@ -446,6 +542,53 @@ def _render_summary(
     )
     table.add_row("Recall", f"{metrics.recall:.4f}", "—", "[dim]informational[/dim]")
     table.add_row("F1", f"{metrics.f1:.4f}", "—", "[dim]informational[/dim]")
+    console.print(table)
+
+    if cases_excluded > 0:
+        console.print(
+            f"[yellow]L1 metrics computed on {cases_included}/{cases_total} "
+            f"cases; {cases_excluded} cases excluded — see Platform Faults "
+            f"panel.[/yellow]"
+        )
+    else:
+        console.print(
+            f"[dim]L1 metrics computed on {cases_included}/{cases_total} cases "
+            f"(no exclusions).[/dim]"
+        )
+
+
+def _render_platform_faults(
+    console: Console, faults: list[CaseDisposition]
+) -> None:
+    """Surface non-success cases prominently. Honest reporting — these
+    cases never reach the metrics aggregation, so without this panel
+    they would silently disappear from the report."""
+    if not faults:
+        console.print(
+            "[dim]No platform faults — every case produced a usable L1 verdict.[/dim]"
+        )
+        return
+    by_state: Counter[str] = Counter(f.state for f in faults)
+    title = (
+        f"Platform Faults — {len(faults)} case(s) excluded "
+        f"({by_state.get(CASE_STATE_PLATFORM_FAULT, 0)} platform_fault, "
+        f"{by_state.get(CASE_STATE_L1_VERDICT_MISSING, 0)} l1_verdict_missing)"
+    )
+    table = Table(
+        title=title,
+        show_header=True,
+        header_style="bold red",
+    )
+    table.add_column("case_id")
+    table.add_column("state")
+    table.add_column("reason")
+    for f in faults:
+        state_label = (
+            f"[red]{f.state}[/red]"
+            if f.state == CASE_STATE_PLATFORM_FAULT
+            else f"[yellow]{f.state}[/yellow]"
+        )
+        table.add_row(f.case_id, state_label, f.reason)
     console.print(table)
 
 
@@ -615,16 +758,20 @@ def render_verification_report(
             f"benchmark pair."
         )
 
-    evidence_list: list[CaseEvidence] = []
-    for cid in case_ids:
-        evidence_list.append(
-            _gather_case_evidence(
-                case_id=cid,
-                batch_run_dir=batch_run_dir,
-                single_eval_root=single_eval_root,
-                benchmark_case=benchmark_cases[cid],
-            )
+    dispositions: list[CaseDisposition] = [
+        _classify_disposition(
+            case_id=cid,
+            batch_run_dir=batch_run_dir,
+            single_eval_root=single_eval_root,
+            benchmark_case=benchmark_cases[cid],
         )
+        for cid in case_ids
+    ]
+    successes = [d for d in dispositions if d.state == CASE_STATE_SUCCESS]
+    faults = [d for d in dispositions if d.state != CASE_STATE_SUCCESS]
+    evidence_list: list[CaseEvidence] = [
+        d.evidence for d in successes if d.evidence is not None
+    ]
 
     classifications = [_classify_case(e) for e in evidence_list]
     metrics = _aggregate_metrics(classifications)
@@ -634,6 +781,15 @@ def render_verification_report(
         tolerance_detection=tolerance_detection,
         target_precision=target_precision,
     )
+    if faults:
+        # Surface in findings too, not just the panel — verdict
+        # consumers reading just the findings list shouldn't be left
+        # in the dark about excluded cases.
+        findings.append(
+            f"{len(faults)} case(s) excluded from metrics due to "
+            f"upstream platform faults / missing verdicts; see Platform "
+            f"Faults panel for per-case detail."
+        )
 
     boundary_summary: dict[str, Counter[str]] = {}
     for ev in evidence_list:
@@ -663,7 +819,11 @@ def render_verification_report(
         target_detection=target_detection,
         tolerance_detection=tolerance_detection,
         target_precision=target_precision,
+        cases_included=len(evidence_list),
+        cases_total=len(case_ids),
+        cases_excluded=len(faults),
     )
+    _render_platform_faults(console, faults)
     _render_metrics_detail(console, metrics)
     _render_per_case_attribution(console, classifications)
     _render_subcap_events(console, layer, sample_evidence, boundary_summary)
@@ -708,6 +868,19 @@ def render_verification_report(
                 "findings": findings,
                 "batch_run_dir": str(batch_run_dir),
                 "single_eval_root": str(single_eval_root),
+                "case_inclusion": {
+                    "included": len(evidence_list),
+                    "total": len(case_ids),
+                    "excluded": len(faults),
+                    "excluded_cases": [
+                        {
+                            "case_id": f.case_id,
+                            "state": f.state,
+                            "reason": f.reason,
+                        }
+                        for f in faults
+                    ],
+                },
             },
             indent=2,
         ),

--- a/src/llm_judge/benchmarks/registry.py
+++ b/src/llm_judge/benchmarks/registry.py
@@ -44,6 +44,12 @@ RAGTRUTH_50_BENCHMARK_PATH = Path(
     "datasets/benchmarks/ragtruth/ragtruth_50_benchmark.json"
 )
 
+# RAGTruth-5 — strict 5-id prefix of ragtruth_50, used as a fast slice
+# for integration tests of the platform-as-harness verification flow.
+RAGTRUTH_5_BENCHMARK_PATH = Path(
+    "datasets/benchmarks/ragtruth/ragtruth_5_benchmark.json"
+)
+
 
 class BenchmarkNotFoundError(Exception):
     """Raised by :func:`build` when a benchmark name is not registered."""
@@ -105,7 +111,15 @@ def _build_ragtruth_50() -> BenchmarkAdapter:
     return adapter
 
 
+def _build_ragtruth_5() -> BenchmarkAdapter:
+    """Build a RAGTruthAdapter restricted to the 5-case test slice."""
+    adapter = RAGTruthAdapter()
+    adapter.set_benchmark_filter(RAGTRUTH_5_BENCHMARK_PATH)
+    return adapter
+
+
 register("ragtruth_50", _build_ragtruth_50)
+register("ragtruth_5", _build_ragtruth_5)
 register("halueval", HaluEvalAdapter)
 register("fever", FEVERAdapter)
 register("ifeval", IFEvalAdapter)

--- a/src/llm_judge/calibration/hallucination.py
+++ b/src/llm_judge/calibration/hallucination.py
@@ -31,6 +31,12 @@ from dataclasses import dataclass, field
 from difflib import SequenceMatcher
 from typing import TYPE_CHECKING, Any
 
+from llm_judge.control_plane.observability import (
+    Timer,
+    emit_event,
+    emit_sub_capability_skipped,
+)
+
 if TYPE_CHECKING:
     from llm_judge.calibration.pipeline_config import PipelineConfig
 
@@ -640,20 +646,59 @@ def check_hallucination(
         )
 
     # -- L1: Rules — exact substring match (cheapest, runs first) --
-    l1_resolved = set()
+    l1_resolved: set[int] = set()
     if l1_enabled:
-        for i, sent in enumerate(resp_sents):
-            if _l1_substring_match(sent, ctx_sents, source_doc):
-                l1_resolved.add(i)
-                layer_stats["L1"] += 1
-                sentence_results.append(
-                    SentenceLayerResult(
-                        sentence_idx=i,
-                        sentence=sent[:120],
-                        resolved_by="L1",
-                        detail="exact_match",
+        # CAP-7 L1 sub-capability instrumentation (CAP-7 phase 1).
+        # Four conceptual boundaries; one CLEAN, three SOFT. Soft
+        # boundaries emit ``sub_capability_skipped`` with explicit
+        # reasons rather than 0ms-duration events (D5).
+        emit_sub_capability_skipped(
+            capability_id="CAP-7",
+            sub_capability_id="l1_input_preparation",
+            request_id=case_id,
+            reason="sentence_segmentation_shared_across_layers",
+        )
+
+        emit_event(
+            "sub_capability_started",
+            capability_id="CAP-7",
+            sub_capability_id="l1_substring_matching",
+            request_id=case_id,
+        )
+        with Timer() as _t_l1_match:
+            for i, sent in enumerate(resp_sents):
+                if _l1_substring_match(sent, ctx_sents, source_doc):
+                    l1_resolved.add(i)
+                    layer_stats["L1"] += 1
+                    sentence_results.append(
+                        SentenceLayerResult(
+                            sentence_idx=i,
+                            sentence=sent[:120],
+                            resolved_by="L1",
+                            detail="exact_match",
+                        )
                     )
-                )
+        emit_event(
+            "sub_capability_completed",
+            capability_id="CAP-7",
+            sub_capability_id="l1_substring_matching",
+            request_id=case_id,
+            duration_ms=_t_l1_match.duration_ms,
+            status="success",
+        )
+
+        emit_sub_capability_skipped(
+            capability_id="CAP-7",
+            sub_capability_id="l1_aggregation",
+            request_id=case_id,
+            reason="interleaved_with_substring_matching_loop",
+        )
+        emit_sub_capability_skipped(
+            capability_id="CAP-7",
+            sub_capability_id="l1_result_emission",
+            request_id=case_id,
+            reason="no_discrete_emit_step_layer_stats_flow_through_hallucination_result",
+        )
 
     # If ALL sentences resolved by L1, skip everything else
     if len(l1_resolved) == len(resp_sents):

--- a/src/llm_judge/calibration/hallucination.py
+++ b/src/llm_judge/calibration/hallucination.py
@@ -631,6 +631,7 @@ def check_hallucination(
         "L3_deberta": 0,
         "L4_supported": 0,
         "L4_unsupported": 0,
+        "total_sentences": len(resp_sents),
     }
 
     if not resp_sents or not ctx_sents:

--- a/src/llm_judge/control_plane/batch_runner.py
+++ b/src/llm_judge/control_plane/batch_runner.py
@@ -84,6 +84,8 @@ class BatchRunner:
         batch_id: str,
         output_dir: Path,
         source: str,
+        *,
+        layers: list[str] | None = None,
     ) -> BatchResult:
         """Run every case in ``cases`` through the PlatformRunner.
 
@@ -99,6 +101,12 @@ class BatchRunner:
         It is included in ``batch_started`` and on the returned
         BatchResult so downstream reports can show where the cases
         came from.
+
+        ``layers`` is forwarded to ``PlatformRunner.run_single_evaluation``
+        and constrains which CAP-7 hallucination-pipeline layers run for
+        every case in the batch. ``None`` (the default) preserves the
+        Runner's default layer selection. Used by the verification flow
+        (``--isolate-layer``) to run a single layer in isolation.
         """
         cases_list = list(cases)
         total = len(cases_list)
@@ -139,6 +147,7 @@ class BatchRunner:
                         case=case,
                         case_id=case_id,
                         manifest_path=manifest_path,
+                        layers=layers,
                     )
 
                 # ``case_timer.duration_ms`` is the authoritative wall
@@ -208,6 +217,7 @@ class BatchRunner:
         case: SingleEvaluationRequest,
         case_id: str,
         manifest_path: Path,
+        layers: list[str] | None = None,
     ) -> tuple[CaseResult, str]:
         """Run one case through the PlatformRunner.
 
@@ -216,9 +226,11 @@ class BatchRunner:
         capability success), ``"failure"`` (one or more tolerated
         capability failures), or ``"error"`` (CAP-5 propagated or an
         unexpected exception).
+
+        ``layers`` is passed through to the Runner unchanged.
         """
         try:
-            result = self._runner.run_single_evaluation(case)
+            result = self._runner.run_single_evaluation(case, layers=layers)
         except Exception as exc:
             manifest_path.write_text("{}", encoding="utf-8")
             return (

--- a/src/llm_judge/control_plane/wrappers.py
+++ b/src/llm_judge/control_plane/wrappers.py
@@ -389,6 +389,15 @@ def invoke_cap7(
         "flags": list(result.flags),
         "layer_stats": dict(result.layer_stats),
         "layers_requested": list(requested),
+        "sentence_results": [
+            {
+                "sentence_idx": sr.sentence_idx,
+                "sentence": sr.sentence,
+                "resolved_by": sr.resolved_by,
+                "detail": sr.detail,
+            }
+            for sr in result.sentence_results
+        ],
     }
 
     stamped = envelope.stamped(capability="CAP-7")

--- a/src/llm_judge/datasets/registry.py
+++ b/src/llm_judge/datasets/registry.py
@@ -142,12 +142,14 @@ class DatasetRegistry:
             security_warnings = _check_security(raw_cases, data_path)
             if security_warnings:
                 for sw in security_warnings[:5]:
+                    # ``extra`` keys cannot shadow LogRecord built-ins
+                    # ("message" is reserved); use warning_message instead.
                     logger.warning(
                         "dataset.security_warning",
                         extra={
                             "dataset_id": dataset_id,
                             "code": sw.code,
-                            "message": sw.message,
+                            "warning_message": sw.message,
                         },
                     )
         except ImportError:

--- a/tests/calibration/test_hallucination_l1_instrumentation.py
+++ b/tests/calibration/test_hallucination_l1_instrumentation.py
@@ -1,0 +1,194 @@
+"""L1 sub-capability instrumentation coverage (CAP-7 Phase 1).
+
+Four conceptual boundaries are emitted on every L1-enabled run:
+
+* ``l1_input_preparation`` — SOFT (sentence segmentation runs
+  unconditionally for all layers).
+* ``l1_substring_matching`` — CLEAN (the per-sentence loop is
+  L1-specific; ``started`` + ``completed`` events carry duration).
+* ``l1_aggregation`` — SOFT (interleaved with the matching loop).
+* ``l1_result_emission`` — SOFT (no discrete emission step;
+  ``layer_stats`` flows through to ``HallucinationResult``).
+
+Soft boundaries emit ``sub_capability_skipped`` with explicit
+``reason`` rather than 0ms-duration events (CAP-7 Phase 1 D5).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from structlog.testing import capture_logs
+
+from llm_judge.calibration.hallucination import check_hallucination
+
+L1_SUB_CAPS = (
+    "l1_input_preparation",
+    "l1_substring_matching",
+    "l1_aggregation",
+    "l1_result_emission",
+)
+SOFT_BOUNDARIES = (
+    "l1_input_preparation",
+    "l1_aggregation",
+    "l1_result_emission",
+)
+CLEAN_BOUNDARIES = ("l1_substring_matching",)
+
+
+def _l1_only_kwargs(case_id: str = "test-l1") -> dict[str, Any]:
+    return dict(
+        case_id=case_id,
+        skip_embeddings=True,
+        l1_enabled=True,
+        l2_enabled=False,
+        l3_enabled=False,
+        l4_enabled=False,
+        gate2_routing="none",
+    )
+
+
+def _l1_events(
+    logs: Sequence[Mapping[str, Any]],
+) -> list[Mapping[str, Any]]:
+    return [
+        log
+        for log in logs
+        if log.get("event")
+        in (
+            "sub_capability_started",
+            "sub_capability_completed",
+            "sub_capability_skipped",
+            "sub_capability_failed",
+        )
+        and log.get("capability_id") == "CAP-7"
+        and isinstance(log.get("sub_capability_id"), str)
+        and log["sub_capability_id"].startswith("l1_")
+    ]
+
+
+def test_l1_emits_sub_capability_events_for_all_four_boundaries() -> None:
+    with capture_logs() as logs:
+        check_hallucination(
+            response="Paris is the capital of France.",
+            context="Paris is the capital of France and its largest city.",
+            **_l1_only_kwargs(),
+        )
+
+    seen = {e["sub_capability_id"] for e in _l1_events(logs)}
+    assert seen == set(L1_SUB_CAPS), (
+        f"L1 boundaries: got {sorted(seen)}, expected {sorted(L1_SUB_CAPS)}"
+    )
+
+
+def test_l1_substring_matching_clean_boundary_emits_started_and_completed() -> None:
+    with capture_logs() as logs:
+        check_hallucination(
+            response="Paris is the capital of France.",
+            context="Paris is the capital of France and its largest city.",
+            **_l1_only_kwargs(),
+        )
+
+    started = [
+        log
+        for log in logs
+        if log.get("event") == "sub_capability_started"
+        and log.get("capability_id") == "CAP-7"
+        and log.get("sub_capability_id") == "l1_substring_matching"
+    ]
+    completed = [
+        log
+        for log in logs
+        if log.get("event") == "sub_capability_completed"
+        and log.get("capability_id") == "CAP-7"
+        and log.get("sub_capability_id") == "l1_substring_matching"
+    ]
+    assert len(started) == 1, f"expected 1 started, got {len(started)}"
+    assert len(completed) == 1, f"expected 1 completed, got {len(completed)}"
+    assert completed[0]["status"] == "success"
+    assert completed[0]["duration_ms"] >= 0.0
+    assert completed[0]["request_id"] == "test-l1"
+
+
+def test_l1_soft_boundaries_emit_skipped_with_reason() -> None:
+    with capture_logs() as logs:
+        check_hallucination(
+            response="Paris is the capital of France.",
+            context="Paris is the capital of France and its largest city.",
+            **_l1_only_kwargs(),
+        )
+
+    for sub_cap in SOFT_BOUNDARIES:
+        skipped = [
+            log
+            for log in logs
+            if log.get("event") == "sub_capability_skipped"
+            and log.get("capability_id") == "CAP-7"
+            and log.get("sub_capability_id") == sub_cap
+        ]
+        assert len(skipped) == 1, (
+            f"{sub_cap}: expected 1 skipped event, got {len(skipped)}"
+        )
+        reason = skipped[0].get("reason")
+        assert isinstance(reason, str) and reason, (
+            f"{sub_cap}: reason must be a non-empty string"
+        )
+        assert skipped[0]["request_id"] == "test-l1"
+
+
+def test_l1_input_preparation_metadata_sentence_count_in_result() -> None:
+    """Sentence count is observable via ``len(sentence_results)`` plus
+    L1's ``layer_stats['L1']`` count of matched sentences. Sub-capability
+    events themselves carry only the contract fields (event-shape tests
+    enforce no extras), so metadata lives in the result payload.
+    """
+    response = "Paris is the capital of France. The Eiffel Tower stands in Paris."
+    context = (
+        "Paris is the capital of France. The Eiffel Tower stands in Paris and "
+        "is its most famous landmark."
+    )
+    result = check_hallucination(
+        response=response,
+        context=context,
+        **_l1_only_kwargs("test-l1-meta-sents"),
+    )
+    assert "L1" in result.layer_stats
+    assert isinstance(result.layer_stats["L1"], int)
+
+
+def test_l1_substring_matching_metadata_match_count_in_layer_stats() -> None:
+    # Ensure the response sentence appears verbatim (including trailing
+    # period) in the context so the cheapest substring check fires.
+    response = "Paris is the capital of France."
+    context = (
+        "Background information follows. Paris is the capital of France. "
+        "It is also home to the Eiffel Tower."
+    )
+    result = check_hallucination(
+        response=response,
+        context=context,
+        **_l1_only_kwargs("test-l1-meta-match"),
+    )
+    assert result.layer_stats["L1"] >= 1, (
+        f"L1 should match at least 1 sentence; layer_stats={result.layer_stats}"
+    )
+
+
+def test_l1_disabled_emits_no_sub_capability_events() -> None:
+    with capture_logs() as logs:
+        check_hallucination(
+            response="Paris is the capital of France.",
+            context="Paris is the capital of France.",
+            case_id="test-l1-disabled",
+            skip_embeddings=True,
+            l1_enabled=False,
+            l2_enabled=False,
+            l3_enabled=False,
+            l4_enabled=False,
+            gate2_routing="none",
+        )
+
+    assert _l1_events(logs) == [], (
+        "L1 disabled must emit no sub-capability events"
+    )

--- a/tests/calibration/test_l1_completion_integration.py
+++ b/tests/calibration/test_l1_completion_integration.py
@@ -1,0 +1,295 @@
+"""L1 completion integration tests (Phase 1 closure).
+
+Asserts the four exit criteria for declaring L1 'done' through the
+platform-as-harness flow — every assertion goes through the same
+artifacts a human would inspect, no platform bypass:
+
+  1. **Algorithm correctness** — L1 produces specific, deterministic
+     outputs on a fixed synthetic corpus. Regression-detects any
+     change to the substring-match or sentence-segmentation logic
+     that would invalidate the empirical RAGTruth-50 result.
+
+  2. **RAGTruth-50 verification PASSED** — the canonical pre-flight
+     is captured as a verification_summary.json artifact written by
+     ``make verify-l1`` and committed to the PR description; this
+     test asserts the locally-runnable ragtruth_5 slice exhibits the
+     same precision invariant (100%) the full run did.
+
+  3. **Cascade wired** — ``DEFAULT_LAYERS`` from the wrappers module
+     contains ``"L1"``, so the no-flag default path actually runs
+     L1.
+
+  4. **Sub-capability instrumentation** — running L1 emits all four
+     boundary events (one CLEAN, three SOFT-with-reason) AND those
+     events propagate through the platform into the per-case
+     ``events.jsonl`` written by the batch runner.
+
+The integration test uses RAGTruth-5 (5-case slice). Full RAGTruth-50
+verification ran in pre-flight (``make verify-l1``); its output is
+captured in the PR description, not re-run here.
+
+Regression test #1 uses a fixed synthetic corpus — no benchmark data
+needed, no spaCy variability to worry about beyond the model version
+already pinned in CI.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from structlog.testing import capture_logs
+
+from llm_judge.calibration.hallucination import check_hallucination
+from llm_judge.control_plane.event_bus import get_default_bus
+from llm_judge.control_plane.wrappers import DEFAULT_LAYERS
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+@pytest.fixture(autouse=True)
+def _clear_event_bus() -> None:
+    get_default_bus().clear()
+    yield
+    get_default_bus().clear()
+
+
+# Synthetic corpus pinned for the regression test. Sentence text is
+# chosen so spaCy splits cleanly on '.' and the substring matcher's
+# thresholds (exact, 0.85 SequenceMatcher, 0.80 Jaccard) produce
+# unambiguous results — robust against minor spaCy / tokenizer drift.
+_REGRESSION_RESPONSE = (
+    "Paris is the capital of France. "
+    "It is also the largest city in the country. "
+    "The Sahara Desert is in fact a small lake near Berlin."
+)
+_REGRESSION_CONTEXT = (
+    "Paris is the capital of France. "
+    "Paris is the most populous city of France."
+)
+# Sentence 0 is a perfect substring match.
+# Sentence 1 paraphrases context but doesn't substring/Jaccard-match.
+# Sentence 2 is a fabrication (unrelated content).
+_EXPECTED_L1_CLEARED = 1
+
+
+def test_l1_algorithm_unchanged_on_regression_corpus() -> None:
+    """Exit criterion 1 — algorithm correctness.
+
+    On the fixed synthetic corpus, L1 clears exactly the sentences it
+    should: the verbatim-match sentence, and only that one. Any change
+    to L1's substring / Jaccard / SequenceMatcher thresholds, or to the
+    spaCy splitter's behavior, will trip this test before it ships.
+
+    No platform plumbing here — exercises ``check_hallucination``
+    directly with L1-only knobs (matches the Commit 1 instrumentation
+    test pattern). Frees the test from spaCy / Runner / CAP-5 cost on
+    the regression path.
+    """
+    result = check_hallucination(
+        response=_REGRESSION_RESPONSE,
+        context=_REGRESSION_CONTEXT,
+        case_id="regression-l1",
+        skip_embeddings=True,
+        l1_enabled=True,
+        l2_enabled=False,
+        l3_enabled=False,
+        l4_enabled=False,
+        gate2_routing="none",
+    )
+    assert result.layer_stats["L1"] == _EXPECTED_L1_CLEARED, (
+        f"L1 should clear exactly {_EXPECTED_L1_CLEARED} sentence on the "
+        f"regression corpus; got {result.layer_stats['L1']}. Stats: "
+        f"{result.layer_stats}"
+    )
+    # total_sentences exposure (CAP-7 wrapper change in Commit 2).
+    assert result.layer_stats["total_sentences"] == 3
+    # The cleared sentence's resolved_by attribution is preserved.
+    cleared = [sr for sr in result.sentence_results if sr.resolved_by == "L1"]
+    assert len(cleared) == _EXPECTED_L1_CLEARED
+
+
+def test_l1_in_default_layers() -> None:
+    """Exit criterion 3 — cascade wired.
+
+    Without ``--isolate-layer``, the platform routes through
+    ``DEFAULT_LAYERS``. L1 must be in that tuple, otherwise the
+    no-flag default path silently bypasses L1.
+    """
+    assert "L1" in DEFAULT_LAYERS, (
+        f"L1 missing from DEFAULT_LAYERS={DEFAULT_LAYERS!r} — the "
+        f"no-flag default path would skip L1."
+    )
+
+
+def test_l1_sub_capability_events_fire_via_check_hallucination() -> None:
+    """Exit criterion 4a — instrumentation fires at the function level.
+
+    Confirms the four L1 boundary events are emitted by
+    ``check_hallucination`` regardless of whether anything wraps it.
+    Complements the platform-level assertion below.
+    """
+    with capture_logs() as logs:
+        check_hallucination(
+            response=_REGRESSION_RESPONSE,
+            context=_REGRESSION_CONTEXT,
+            case_id="instr-l1",
+            skip_embeddings=True,
+            l1_enabled=True,
+            l2_enabled=False,
+            l3_enabled=False,
+            l4_enabled=False,
+            gate2_routing="none",
+        )
+    seen = {
+        log["sub_capability_id"]
+        for log in logs
+        if log.get("capability_id") == "CAP-7"
+        and isinstance(log.get("sub_capability_id"), str)
+        and log["sub_capability_id"].startswith("l1_")
+    }
+    expected = {
+        "l1_input_preparation",
+        "l1_substring_matching",
+        "l1_aggregation",
+        "l1_result_emission",
+    }
+    assert seen == expected, f"missing L1 boundaries: {expected - seen}"
+
+
+def test_l1_meets_all_four_exit_criteria_via_platform() -> None:
+    """The canonical 'L1 is done' integration test.
+
+    Runs --isolate-layer L1 on RAGTruth-5 through the platform, renders
+    the verification report, then asserts each exit criterion against
+    the rendered artifacts:
+
+      1. Algorithm correctness (sentence-level): precision == 1.0 on
+         the slice. The full RAGTruth-50 PASS verdict is captured in
+         the PR description (pre-flight artifact); the slice
+         re-confirms the precision invariant locally.
+      2. Verification flow itself works: report files (HTML, MD, JSON
+         summary) exist with expected structure.
+      3. Cascade wired: ``verdict.layers_requested == ["L1"]`` in
+         each per-case CAP-5 manifest.
+      4. Instrumentation fires through the platform: per-case
+         ``events.jsonl`` carries the four L1 boundary events.
+
+    Slice strategy: Option 1 — registered ``ragtruth_5`` benchmark
+    (5-id prefix of ragtruth_50). Bounded scope: one factory closure
+    in the registry, one new JSON file. Option 2 (fixture batch_run)
+    was the fallback and was not needed.
+    """
+    cmd = [
+        sys.executable,
+        str(REPO_ROOT / "tools" / "run_batch_evaluation.py"),
+        "--benchmark",
+        "ragtruth_5",
+        "--isolate-layer",
+        "L1",
+    ]
+    completed = subprocess.run(
+        cmd,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert completed.returncode == 0, (
+        f"batch run failed (rc={completed.returncode}):\n"
+        f"STDERR: {completed.stderr[-500:]}"
+    )
+
+    runs_root = REPO_ROOT / "reports" / "batch_runs"
+    batch_dir = max(
+        (d for d in runs_root.iterdir() if d.name.startswith("batch-")),
+        key=lambda p: p.stat().st_mtime,
+    )
+
+    # Render via the same module the Makefile invokes.
+    from experiments.render_layer_verification_report import (
+        render_verification_report,
+    )
+
+    output_dir = batch_dir / "verification_out"
+    verdict = render_verification_report(
+        batch_run_dir=batch_dir,
+        single_eval_root=REPO_ROOT / "reports" / "single_eval",
+        benchmark="ragtruth_5",
+        layer="L1",
+        target_detection=0.074,
+        tolerance_detection=0.005,
+        target_precision=1.0,
+        output_dir=output_dir,
+    )
+
+    # ── Criterion 1 — algorithm correctness on the slice ─────────────
+    summary = json.loads(
+        (output_dir / "verification_summary.json").read_text(encoding="utf-8")
+    )
+    assert summary["metrics"]["precision"] == 1.0, (
+        f"precision regressed: {summary['metrics']['precision']} "
+        f"(verdict={verdict})"
+    )
+
+    # ── Criterion 2 — verification flow produced report artifacts ────
+    assert (output_dir / "verification_report.html").is_file()
+    assert (output_dir / "verification_report.md").is_file()
+    assert (output_dir / "verification_summary.json").is_file()
+    md = (output_dir / "verification_report.md").read_text(encoding="utf-8")
+    for section in ("Verification summary", "Per-case attribution", "Findings"):
+        assert section in md, f"verification report missing section: {section}"
+    # No platform faults expected on ragtruth_5 (cases 0-4 don't trip the
+    # security_warning path that previously crashed CAP-1).
+    assert summary["case_inclusion"]["excluded"] == 0, (
+        f"ragtruth_5 produced unexpected fault cases: "
+        f"{summary['case_inclusion']['excluded_cases']}"
+    )
+
+    # ── Criterion 3 — cascade wired (verdict.layers_requested) ────────
+    case_ids = sorted(d.name for d in (batch_dir / "cases").iterdir())
+    assert case_ids, "no cases written"
+    for cid in case_ids:
+        cap5_manifest = json.loads(
+            (REPO_ROOT / "reports" / "single_eval" / cid / "manifest.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        layers_req = cap5_manifest["verdict"]["layers_requested"]
+        assert layers_req == ["L1"], (
+            f"{cid}: layers_requested={layers_req!r}, expected ['L1']"
+        )
+
+    # ── Criterion 4 — instrumentation fires via the platform ──────────
+    expected_boundaries = {
+        "l1_input_preparation",
+        "l1_substring_matching",
+        "l1_aggregation",
+        "l1_result_emission",
+    }
+    sample_events_path = batch_dir / "cases" / case_ids[0] / "events.jsonl"
+    with sample_events_path.open("r", encoding="utf-8") as f:
+        sample_events = [json.loads(line) for line in f if line.strip()]
+    seen_boundaries = {
+        ev["sub_capability_id"]
+        for ev in sample_events
+        if ev.get("capability_id") == "CAP-7"
+        and isinstance(ev.get("sub_capability_id"), str)
+        and ev["sub_capability_id"].startswith("l1_")
+    }
+    assert seen_boundaries == expected_boundaries, (
+        f"missing L1 boundaries in {sample_events_path}: "
+        f"{expected_boundaries - seen_boundaries}"
+    )
+
+    # Closure assertion — verdict on the slice is PASS or PARTIAL,
+    # never FAIL (FAIL would mean precision regression which already
+    # failed Criterion 1 above; defensive belt-and-braces).
+    assert verdict in ("PASS", "PARTIAL"), (
+        f"slice verdict={verdict}, expected PASS or PARTIAL"
+    )

--- a/tests/calibration/test_layer_verification_renderer.py
+++ b/tests/calibration/test_layer_verification_renderer.py
@@ -1,0 +1,363 @@
+"""Tests for the platform-as-harness verification flow (Commit 2).
+
+Covers the three pieces that ship together:
+
+  1. ``--isolate-layer`` argparse flag in ``tools/run_batch_evaluation.py``
+     plumbs through to CAP-7 such that the layer constraint is observable
+     in batch_run + single_eval artifacts.
+  2. ``experiments/render_layer_verification_report.py`` reads only
+     existing artifacts (no pipeline re-invocation), classifies each
+     sentence into TP/FP/TN/FN, and renders HTML + Markdown.
+  3. PASS / FAIL / PARTIAL verdict logic on synthetic metrics — no
+     pipeline involvement.
+
+The plumbing test uses the ``ragtruth_5`` slice (5-case prefix of
+``ragtruth_50``) so it runs in well under a minute. Full RAGTruth-50
+verification is the pre-flight artifact captured in the PR — not a
+test-suite obligation.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+# experiments/ isn't a Python package — make its modules importable for
+# the test process the same way tools/run_batch_evaluation.py does for
+# its sibling helpers (sys.path shim at script entry).
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from experiments.render_layer_verification_report import (  # noqa: E402
+    CaseClassification,
+    CaseEvidence,
+    VerificationMetrics,
+    _aggregate_metrics,
+    _classify_case,
+    _compute_verdict,
+    render_verification_report,
+)
+from llm_judge.control_plane.event_bus import get_default_bus  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _clear_event_bus() -> None:
+    """Avoid event-bus subscriber leakage between tests."""
+    get_default_bus().clear()
+    yield
+    get_default_bus().clear()
+
+
+# ----------------------------------------------------------------------
+# Verdict logic — synthetic metrics, no pipeline
+# ----------------------------------------------------------------------
+
+
+def _metrics(*, tp: int, fp: int, tn: int, fn: int) -> VerificationMetrics:
+    total = tp + fp + tn + fn
+    detection = (tp + fp) / total if total else 0.0
+    precision = tp / (tp + fp) if (tp + fp) else 0.0
+    recall = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+    return VerificationMetrics(
+        total_sentences=total,
+        total_responses=10,
+        tp=tp,
+        fp=fp,
+        tn=tn,
+        fn=fn,
+        detection_rate=detection,
+        precision=precision,
+        recall=recall,
+        f1=f1,
+    )
+
+
+def test_verdict_pass_when_in_tolerance_and_at_target_precision() -> None:
+    metrics = _metrics(tp=22, fp=0, tn=18, fn=263)
+    verdict, findings = _compute_verdict(
+        metrics,
+        target_detection=0.074,
+        tolerance_detection=0.005,
+        target_precision=1.0,
+    )
+    assert verdict == "PASS", f"expected PASS, got {verdict} ({findings})"
+    assert any("Precision" in line for line in findings)
+    assert any("Detection rate" in line for line in findings)
+
+
+def test_verdict_fail_when_precision_below_target() -> None:
+    metrics = _metrics(tp=20, fp=2, tn=18, fn=263)
+    verdict, findings = _compute_verdict(
+        metrics,
+        target_detection=0.074,
+        tolerance_detection=0.005,
+        target_precision=1.0,
+    )
+    assert verdict == "FAIL"
+    assert any("below target" in line for line in findings)
+
+
+def test_verdict_partial_when_precision_passes_but_detection_outside_tolerance() -> None:
+    metrics = _metrics(tp=33, fp=0, tn=20, fn=250)
+    verdict, findings = _compute_verdict(
+        metrics,
+        target_detection=0.074,
+        tolerance_detection=0.005,
+        target_precision=1.0,
+    )
+    assert verdict == "PARTIAL"
+    assert any("OUTSIDE tolerance" in line for line in findings)
+
+
+# ----------------------------------------------------------------------
+# Renderer classification — synthetic CaseEvidence
+# ----------------------------------------------------------------------
+
+
+def _evidence_from_sentences(
+    sentences: list[str],
+    *,
+    cleared_indices: set[int],
+    span_texts: list[str],
+    case_id: str = "synthetic_0",
+) -> CaseEvidence:
+    """Build a CaseEvidence whose response splits into the supplied sentences.
+
+    The renderer re-invokes ``_split_sentences`` on the response, so the
+    response must be a deterministic concatenation that yields exactly
+    these sentences after spaCy splitting + the >10-char filter.
+    """
+    response = " ".join(s.strip() for s in sentences) + " "
+    return CaseEvidence(
+        case_id=case_id,
+        response_text=response,
+        sentence_count=len(sentences),
+        layers_requested=["L1"],
+        layer_stats={"L1": len(cleared_indices), "total_sentences": len(sentences)},
+        cleared_indices=cleared_indices,
+        sub_capability_events=[],
+        span_annotations=[
+            {"start": 0, "end": len(t), "text": t, "label_type": "Evident Baseless Info"}
+            for t in span_texts
+        ],
+    )
+
+
+def test_classify_case_tp_when_cleared_sentence_has_no_overlapping_span() -> None:
+    sentences = [
+        "The capital of France is Paris.",
+        "It is the largest metropolitan area in the country.",
+    ]
+    evidence = _evidence_from_sentences(
+        sentences, cleared_indices={0}, span_texts=[]
+    )
+    classification = _classify_case(evidence)
+    # idx 0 cleared and grounded → TP; idx 1 uncleared and grounded → FN
+    assert classification.tp == 1
+    assert classification.fp == 0
+    assert classification.tn == 0
+    assert classification.fn == 1
+
+
+def test_classify_case_fp_when_cleared_sentence_contains_a_span() -> None:
+    sentences = [
+        "The capital of France is Paris.",
+        "Paris was founded in the year nineteen ninety nine.",
+    ]
+    # L1 incorrectly clears sentence 1 even though it contains a hallucinated
+    # span ("nineteen ninety nine") — that's a false positive at L1.
+    evidence = _evidence_from_sentences(
+        sentences,
+        cleared_indices={1},
+        span_texts=["nineteen ninety nine"],
+    )
+    classification = _classify_case(evidence)
+    assert classification.fp == 1, (
+        f"expected FP=1, got {classification.fp}; tp={classification.tp}, "
+        f"tn={classification.tn}, fn={classification.fn}"
+    )
+    # idx 0 was uncleared and grounded → FN
+    assert classification.fn == 1
+
+
+def test_aggregate_metrics_sums_across_cases_and_handles_zero_division() -> None:
+    classifications = [
+        CaseClassification(case_id="a", sentence_count=3, tp=2, fp=0, tn=0, fn=1),
+        CaseClassification(case_id="b", sentence_count=3, tp=0, fp=0, tn=3, fn=0),
+    ]
+    metrics = _aggregate_metrics(classifications)
+    assert metrics.tp == 2
+    assert metrics.fp == 0
+    assert metrics.tn == 3
+    assert metrics.fn == 1
+    # total = 6; detection = 2/6 = 0.333...
+    assert metrics.detection_rate == pytest.approx(2 / 6)
+    # precision = 2/2 = 1.0; recall = 2/3 = 0.667
+    assert metrics.precision == pytest.approx(1.0)
+    assert metrics.recall == pytest.approx(2 / 3)
+
+
+def test_aggregate_metrics_zero_total_does_not_divide_by_zero() -> None:
+    metrics = _aggregate_metrics([])
+    assert metrics.detection_rate == 0.0
+    assert metrics.precision == 0.0
+    assert metrics.recall == 0.0
+    assert metrics.f1 == 0.0
+
+
+# ----------------------------------------------------------------------
+# CLI plumbing — small ragtruth_5 slice through the platform
+# ----------------------------------------------------------------------
+
+
+def _run_batch_isolated(layer: str, batch_root: Path) -> Path:
+    """Invoke run_batch_evaluation.py with --isolate-layer and return the run dir.
+
+    The script writes its run directory to stdout in the form
+    ``output: reports/batch_runs/<id>/``. The CWD-relative path is
+    normalised to ``REPO_ROOT`` so the test passes regardless of the
+    pytest invocation directory.
+    """
+    cmd = [
+        sys.executable,
+        str(REPO_ROOT / "tools" / "run_batch_evaluation.py"),
+        "--benchmark",
+        "ragtruth_5",
+        "--isolate-layer",
+        layer,
+    ]
+    result = subprocess.run(
+        cmd,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert result.returncode == 0, (
+        f"run_batch_evaluation.py failed (rc={result.returncode}):\n"
+        f"STDOUT: {result.stdout[-500:]}\n"
+        f"STDERR: {result.stderr[-500:]}"
+    )
+    # Find the latest run dir under reports/batch_runs.
+    runs_root = REPO_ROOT / "reports" / "batch_runs"
+    candidates = sorted(
+        (d for d in runs_root.iterdir() if d.name.startswith("batch-")),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    assert candidates, f"no batch_runs created under {runs_root}"
+    return candidates[0]
+
+
+def test_isolate_layer_l1_constrains_cap7_visible_in_artifacts(
+    tmp_path: Path,
+) -> None:
+    """End-to-end: --isolate-layer L1 → events.jsonl shows L1 fired,
+    CAP-5 manifest shows layers_requested == ['L1'] and L2/L3/L4 = 0.
+
+    Uses ragtruth_5 (5-case slice). Tagged ``slow`` because it loads
+    spaCy + writes platform artifacts; expect ~10-30s.
+    """
+    run_dir = _run_batch_isolated("L1", tmp_path)
+    case_dirs = sorted((run_dir / "cases").iterdir())
+    assert case_dirs, f"no per-case dirs under {run_dir / 'cases'}"
+
+    case_id = case_dirs[0].name
+    events_path = case_dirs[0] / "events.jsonl"
+    cap5_manifest_path = REPO_ROOT / "reports" / "single_eval" / case_id / "manifest.json"
+
+    # 1. events.jsonl shows L1 sub_capability events fired.
+    with events_path.open("r", encoding="utf-8") as f:
+        events = [json.loads(line) for line in f if line.strip()]
+    cap7_events = [e for e in events if e.get("capability_id") == "CAP-7"]
+    assert any(
+        e.get("event") == "sub_capability_started"
+        and e.get("sub_capability_id") == "l1_substring_matching"
+        for e in cap7_events
+    ), "expected CAP-7 l1_substring_matching sub_capability_started event"
+
+    # 2. CAP-5 manifest shows isolation: layers_requested == ['L1'], L2/L3/L4 zero.
+    cap5_manifest = json.loads(cap5_manifest_path.read_text(encoding="utf-8"))
+    verdict = cap5_manifest["verdict"]
+    assert verdict["layers_requested"] == ["L1"], (
+        f"expected layers_requested=['L1'], got {verdict['layers_requested']}"
+    )
+    layer_stats = verdict["layer_stats"]
+    assert layer_stats["L2"] == 0
+    assert layer_stats["L3_deberta"] == 0
+    assert layer_stats["L4_supported"] == 0
+    assert layer_stats["L4_unsupported"] == 0
+    # 3. New verdict surfaces: total_sentences and sentence_results both present.
+    assert "total_sentences" in layer_stats
+    assert "sentence_results" in verdict
+    assert isinstance(verdict["sentence_results"], list)
+
+
+def test_isolate_layer_invalid_value_rejected_by_argparse() -> None:
+    """Argparse rejects layer values outside the L1-L5 choice list."""
+    cmd = [
+        sys.executable,
+        str(REPO_ROOT / "tools" / "run_batch_evaluation.py"),
+        "--benchmark",
+        "ragtruth_5",
+        "--isolate-layer",
+        "L9",
+    ]
+    result = subprocess.run(
+        cmd, cwd=REPO_ROOT, capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode != 0, "expected non-zero exit for invalid layer"
+    # argparse writes the choice error to stderr.
+    assert "L9" in result.stderr or "invalid choice" in result.stderr.lower()
+
+
+# ----------------------------------------------------------------------
+# Renderer end-to-end — runs only after _run_batch_isolated has produced
+# artifacts. Co-located here (rather than its own test) because spinning
+# up another full batch in a fresh test would double the wall time on a
+# path that already covers the same plumbing.
+# ----------------------------------------------------------------------
+
+
+def test_render_verification_report_produces_html_md_and_summary(
+    tmp_path: Path,
+) -> None:
+    """The renderer produces three on-disk artifacts and a non-FAIL verdict
+    on the ragtruth_5 slice (expected: PARTIAL — precision 100%, detection
+    out of tolerance because the slice is too small)."""
+    run_dir = _run_batch_isolated("L1", tmp_path)
+
+    output_dir = tmp_path / "verification_out"
+    verdict = render_verification_report(
+        batch_run_dir=run_dir,
+        single_eval_root=REPO_ROOT / "reports" / "single_eval",
+        benchmark="ragtruth_5",
+        layer="L1",
+        target_detection=0.074,
+        tolerance_detection=0.005,
+        target_precision=1.0,
+        output_dir=output_dir,
+    )
+    # On the 5-case slice, precision must still be 100% — algorithm is
+    # the same. Verdict is PASS or PARTIAL (not FAIL).
+    assert verdict in ("PASS", "PARTIAL"), (
+        f"unexpected verdict {verdict} on ragtruth_5 — precision should "
+        f"hold at 100% even on the slice"
+    )
+
+    assert (output_dir / "verification_report.html").is_file()
+    assert (output_dir / "verification_report.md").is_file()
+    summary_path = output_dir / "verification_summary.json"
+    assert summary_path.is_file()
+    summary: dict[str, Any] = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert summary["layer"] == "L1"
+    assert summary["benchmark"] == "ragtruth_5"
+    assert summary["verdict"] == verdict
+    assert summary["metrics"]["precision"] == 1.0

--- a/tests/calibration/test_layer_verification_renderer.py
+++ b/tests/calibration/test_layer_verification_renderer.py
@@ -35,11 +35,15 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from experiments.render_layer_verification_report import (  # noqa: E402
+    CASE_STATE_L1_VERDICT_MISSING,
+    CASE_STATE_PLATFORM_FAULT,
+    CASE_STATE_SUCCESS,
     CaseClassification,
     CaseEvidence,
     VerificationMetrics,
     _aggregate_metrics,
     _classify_case,
+    _classify_disposition,
     _compute_verdict,
     render_verification_report,
 )
@@ -361,3 +365,313 @@ def test_render_verification_report_produces_html_md_and_summary(
     assert summary["benchmark"] == "ragtruth_5"
     assert summary["verdict"] == verdict
     assert summary["metrics"]["precision"] == 1.0
+    # Three-state inclusion ledger present.
+    assert "case_inclusion" in summary
+    assert summary["case_inclusion"]["total"] == summary["case_inclusion"]["included"]
+    assert summary["case_inclusion"]["excluded"] == 0
+
+
+# ----------------------------------------------------------------------
+# Three-state classification — fixture-driven, no real batch run
+# ----------------------------------------------------------------------
+#
+# These tests build minimal batch_run + single_eval directory layouts
+# under tmp_path and run the renderer against them. They exercise the
+# disposition logic directly without paying spaCy startup more than
+# the renderer would on its successful-case path.
+
+
+def _write_envelope(case_dir: Path, *, integrity: list[dict[str, Any]]) -> None:
+    """Write a per-case batch_run envelope with the supplied integrity list."""
+    case_dir.mkdir(parents=True, exist_ok=True)
+    (case_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "request_id": case_dir.name,
+                "caller_id": "test",
+                "integrity": integrity,
+                "capability_chain": ["CAP-1", "CAP-2", "CAP-7", "CAP-5"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (case_dir / "events.jsonl").write_text("", encoding="utf-8")
+
+
+def _write_cap5_manifest(
+    single_eval_root: Path,
+    case_id: str,
+    *,
+    verdict: dict[str, Any] | None,
+) -> None:
+    """Write a CAP-5 manifest with the supplied verdict shape (or empty)."""
+    case_dir = single_eval_root / case_id
+    case_dir.mkdir(parents=True, exist_ok=True)
+    (case_dir / "manifest.json").write_text(
+        json.dumps({"verdict": verdict or {}, "manifest_id": case_id}),
+        encoding="utf-8",
+    )
+
+
+def _benchmark_case_for_id(case_id: str) -> Any:
+    """Build the smallest BenchmarkCase the renderer needs for a fault path —
+    only ``request.candidate_answer`` and ``ground_truth.span_annotations``
+    are read by ``_classify_disposition``, both of which can be empty for
+    fault cases since classification short-circuits before reading them."""
+    from llm_judge.benchmarks import BenchmarkCase, GroundTruth
+    from llm_judge.schemas import Message, PredictRequest
+
+    return BenchmarkCase(
+        case_id=case_id,
+        request=PredictRequest(
+            conversation=[Message(role="user", content="q")],
+            candidate_answer="The capital of France is Paris.",
+            rubric_id="chat_quality",
+        ),
+        ground_truth=GroundTruth(
+            response_level="pass",
+            property_labels={},
+            span_annotations=[],
+            hallucination_types={},
+        ),
+    )
+
+
+def test_renderer_classifies_platform_fault_when_cap1_failed(tmp_path: Path) -> None:
+    case_dir = tmp_path / "batch_run" / "cases" / "case_a"
+    _write_envelope(
+        case_dir,
+        integrity=[
+            {
+                "capability_id": "CAP-1",
+                "status": "failure",
+                "error_type": "KeyError",
+                "error_message": "boom",
+                "duration_ms": 1.0,
+            },
+            {"capability_id": "CAP-2", "status": "skipped_upstream_failure"},
+            {"capability_id": "CAP-7", "status": "skipped_upstream_failure"},
+        ],
+    )
+    # CAP-5 manifest has empty verdict (matches what the platform writes
+    # when CAP-1 fails) — disposition classifier should short-circuit on
+    # the envelope and not depend on the CAP-5 file.
+    _write_cap5_manifest(tmp_path / "single_eval", "case_a", verdict={})
+
+    disposition = _classify_disposition(
+        case_id="case_a",
+        batch_run_dir=tmp_path / "batch_run",
+        single_eval_root=tmp_path / "single_eval",
+        benchmark_case=_benchmark_case_for_id("case_a"),
+    )
+    assert disposition.state == CASE_STATE_PLATFORM_FAULT
+    assert "CAP-1" in disposition.reason
+    assert "failure" in disposition.reason
+    assert disposition.evidence is None
+
+
+def test_renderer_classifies_l1_verdict_missing_when_cap5_lacks_verdict(
+    tmp_path: Path,
+) -> None:
+    case_dir = tmp_path / "batch_run" / "cases" / "case_b"
+    # CAP-1/2/7 all green — no platform fault.
+    _write_envelope(
+        case_dir,
+        integrity=[
+            {"capability_id": "CAP-1", "status": "success", "duration_ms": 1.0},
+            {"capability_id": "CAP-2", "status": "success", "duration_ms": 1.0},
+            {"capability_id": "CAP-7", "status": "success", "duration_ms": 1.0},
+        ],
+    )
+    # ...but the CAP-5 verdict is empty (e.g. shape regression / older
+    # manifest predating the surfacing change).
+    _write_cap5_manifest(tmp_path / "single_eval", "case_b", verdict={})
+
+    disposition = _classify_disposition(
+        case_id="case_b",
+        batch_run_dir=tmp_path / "batch_run",
+        single_eval_root=tmp_path / "single_eval",
+        benchmark_case=_benchmark_case_for_id("case_b"),
+    )
+    assert disposition.state == CASE_STATE_L1_VERDICT_MISSING
+    assert "verdict" in disposition.reason.lower()
+    assert disposition.evidence is None
+
+
+def test_renderer_classifies_l1_verdict_missing_when_total_sentences_absent(
+    tmp_path: Path,
+) -> None:
+    """Older manifests can carry a ``verdict`` dict but lack
+    ``layer_stats['total_sentences']`` — that's the canonical sign the
+    manifest predates the CAP-7 wrapper change. Renderer should classify
+    as l1_verdict_missing rather than crash."""
+    case_dir = tmp_path / "batch_run" / "cases" / "case_c"
+    _write_envelope(
+        case_dir,
+        integrity=[
+            {"capability_id": "CAP-1", "status": "success", "duration_ms": 1.0},
+            {"capability_id": "CAP-2", "status": "success", "duration_ms": 1.0},
+            {"capability_id": "CAP-7", "status": "success", "duration_ms": 1.0},
+        ],
+    )
+    _write_cap5_manifest(
+        tmp_path / "single_eval",
+        "case_c",
+        verdict={
+            "risk_score": 0.0,
+            "layer_stats": {"L1": 0, "L2": 0},  # no 'total_sentences'
+            "layers_requested": ["L1"],
+        },
+    )
+
+    disposition = _classify_disposition(
+        case_id="case_c",
+        batch_run_dir=tmp_path / "batch_run",
+        single_eval_root=tmp_path / "single_eval",
+        benchmark_case=_benchmark_case_for_id("case_c"),
+    )
+    assert disposition.state == CASE_STATE_L1_VERDICT_MISSING
+    assert "total_sentences" in disposition.reason
+
+
+def test_renderer_metrics_only_aggregate_successful_dispositions(
+    tmp_path: Path,
+) -> None:
+    """Build a 3-case batch where one case is a platform fault and two
+    succeed. Render and verify (a) the Platform Faults panel surfaces
+    the fault, (b) metrics are computed only on the two successful
+    cases, (c) summary JSON's ``case_inclusion`` ledger reflects the
+    split.
+    """
+    batch_dir = tmp_path / "batch_run"
+    single_eval_root = tmp_path / "single_eval"
+
+    # Case A: success — short, clean, all-grounded response.
+    _write_envelope(
+        batch_dir / "cases" / "case_a",
+        integrity=[
+            {"capability_id": "CAP-1", "status": "success", "duration_ms": 1.0},
+            {"capability_id": "CAP-2", "status": "success", "duration_ms": 1.0},
+            {"capability_id": "CAP-7", "status": "success", "duration_ms": 1.0},
+        ],
+    )
+    _write_cap5_manifest(
+        single_eval_root,
+        "case_a",
+        verdict={
+            "risk_score": 0.0,
+            "grounding_ratio": 1.0,
+            "layers_requested": ["L1"],
+            "layer_stats": {"L1": 1, "total_sentences": 1},
+            "sentence_results": [
+                {
+                    "sentence_idx": 0,
+                    "sentence": "The capital of France is Paris.",
+                    "resolved_by": "L1",
+                    "detail": "exact_match",
+                }
+            ],
+        },
+    )
+
+    # Case B: same shape — ensures aggregation across multiple cases.
+    _write_envelope(
+        batch_dir / "cases" / "case_b",
+        integrity=[
+            {"capability_id": "CAP-1", "status": "success", "duration_ms": 1.0},
+            {"capability_id": "CAP-2", "status": "success", "duration_ms": 1.0},
+            {"capability_id": "CAP-7", "status": "success", "duration_ms": 1.0},
+        ],
+    )
+    _write_cap5_manifest(
+        single_eval_root,
+        "case_b",
+        verdict={
+            "risk_score": 0.0,
+            "grounding_ratio": 1.0,
+            "layers_requested": ["L1"],
+            "layer_stats": {"L1": 1, "total_sentences": 1},
+            "sentence_results": [
+                {
+                    "sentence_idx": 0,
+                    "sentence": "The capital of France is Paris.",
+                    "resolved_by": "L1",
+                    "detail": "exact_match",
+                }
+            ],
+        },
+    )
+
+    # Case C: platform fault — CAP-1 failed, no verdict.
+    _write_envelope(
+        batch_dir / "cases" / "case_c",
+        integrity=[
+            {
+                "capability_id": "CAP-1",
+                "status": "failure",
+                "error_type": "KeyError",
+                "error_message": 'Attempt to overwrite "message" in LogRecord',
+                "duration_ms": 1.0,
+            },
+            {"capability_id": "CAP-2", "status": "skipped_upstream_failure"},
+            {"capability_id": "CAP-7", "status": "skipped_upstream_failure"},
+        ],
+    )
+    _write_cap5_manifest(single_eval_root, "case_c", verdict={})
+
+    # Patch the benchmark loader to return all three synthetic cases.
+    import experiments.render_layer_verification_report as mod
+
+    monkey_cases = {
+        cid: _benchmark_case_for_id(cid) for cid in ("case_a", "case_b", "case_c")
+    }
+    original_loader = mod._load_benchmark_cases
+    mod._load_benchmark_cases = lambda _b: monkey_cases  # type: ignore[assignment]
+    try:
+        output_dir = tmp_path / "verification_out"
+        verdict = render_verification_report(
+            batch_run_dir=batch_dir,
+            single_eval_root=single_eval_root,
+            benchmark="synthetic",
+            layer="L1",
+            target_detection=0.5,
+            tolerance_detection=0.5,
+            target_precision=1.0,
+            output_dir=output_dir,
+        )
+    finally:
+        mod._load_benchmark_cases = original_loader  # type: ignore[assignment]
+
+    summary = json.loads(
+        (output_dir / "verification_summary.json").read_text(encoding="utf-8")
+    )
+    # case_a + case_b included, case_c excluded.
+    inclusion = summary["case_inclusion"]
+    assert inclusion["total"] == 3
+    assert inclusion["included"] == 2
+    assert inclusion["excluded"] == 1
+    excluded_ids = [e["case_id"] for e in inclusion["excluded_cases"]]
+    assert excluded_ids == ["case_c"]
+    assert inclusion["excluded_cases"][0]["state"] == CASE_STATE_PLATFORM_FAULT
+
+    # Metrics computed on 2 cases × 1 sentence each = 2 sentences total.
+    assert summary["metrics"]["total_sentences"] == 2
+    assert summary["metrics"]["total_responses"] == 2
+    # Both sentences cleared, both grounded → TP=2, FP=0, precision=1.0.
+    assert summary["metrics"]["tp"] == 2
+    assert summary["metrics"]["fp"] == 0
+    assert summary["metrics"]["precision"] == 1.0
+
+    # Verdict reflects metrics on included cases only — precision passes
+    # (1.0), detection rate is 1.0 which lands inside the [0.0, 1.0]
+    # tolerance window we set up. Either PASS or PARTIAL is acceptable
+    # depending on tolerance bounds; FAIL is not.
+    assert verdict in ("PASS", "PARTIAL")
+    # Findings mention the excluded case.
+    assert any("excluded" in f.lower() for f in summary["findings"])
+
+    # Report markdown includes a Platform Faults section.
+    md = (output_dir / "verification_report.md").read_text(encoding="utf-8")
+    assert "Platform Faults" in md
+    assert "case_c" in md
+

--- a/tests/calibration/test_layer_verification_renderer.py
+++ b/tests/calibration/test_layer_verification_renderer.py
@@ -37,7 +37,6 @@ if str(REPO_ROOT) not in sys.path:
 from experiments.render_layer_verification_report import (  # noqa: E402
     CASE_STATE_L1_VERDICT_MISSING,
     CASE_STATE_PLATFORM_FAULT,
-    CASE_STATE_SUCCESS,
     CaseClassification,
     CaseEvidence,
     VerificationMetrics,

--- a/tools/run_batch_evaluation.py
+++ b/tools/run_batch_evaluation.py
@@ -131,6 +131,21 @@ def _build_argparser() -> argparse.ArgumentParser:
         default=None,
         help="Truncate to the first N cases. Default: no limit.",
     )
+    parser.add_argument(
+        "--isolate-layer",
+        type=str,
+        default=None,
+        choices=["L1", "L2", "L3", "L4", "L5"],
+        help=(
+            "Constrain CAP-7 to a single hallucination-pipeline layer. "
+            "Used by the layer-by-layer verification flow "
+            "(make verify-l1, etc.). Default: None (uses CAP-7 default "
+            "DEFAULT_LAYERS=['L1']). NOTE: L5 is in the choice list to "
+            "keep argparse stable across the level-by-level arc — it "
+            "currently raises ValueError from invoke_cap7 until "
+            "VALID_LAYERS is extended in Phase 5."
+        ),
+    )
     return parser
 
 
@@ -155,12 +170,15 @@ def main(argv: list[str] | None = None) -> int:
     renderer = BatchTerminalRenderer(output_dir)
     renderer.attach()
 
+    layers = [args.isolate_layer] if args.isolate_layer else None
+
     try:
         result = batch_runner.run_batch(
             cases=cases_iter,
             batch_id=batch_id,
             output_dir=output_dir,
             source=source,
+            layers=layers,
         )
     except Exception as exc:
         print(f"batch driver failed: {exc}", file=sys.stderr)


### PR DESCRIPTION
## Summary

Closes Phase 1 (CAP-7 L1 completion). Establishes the **platform-as-harness** pattern for layer-by-layer verification: `--isolate-layer L1` runs through the standard Runner → CAPs → manifests path, then a separate renderer reads the artifacts to compute the verdict. No platform bypass. L2-L5 verification will reuse the same CLI surface and renderer with different `--target-*` parameters.

**RAGTruth-50 verification verdict: PASS.** Detection 7.26% (within tolerance [6.9%, 7.9%]), precision 100% (22 TP, 0 FP), 50/50 cases included.

## Branch shape

Four commits; the original packet specified three but a pre-existing CAP-1 logging bug surfaced during pre-flight that warranted its own commit (architect-chat-approved).

| Commit | Title | Notes |
|---|---|---|
| `8a4e23d` | feat(cap7/l1): sub-capability instrumentation following CP-3 pattern | Unchanged from pre-reset. The four L1 boundaries (1 CLEAN + 3 SOFT-with-reason). |
| `1bc36be` | feat(tools, experiments): platform-as-harness verification flow | `--isolate-layer` flag, verification renderer, `make verify-l1` target, `ragtruth_5` benchmark registration. |
| `17c041c` | fix(datasets): logging bug + verification renderer fault tolerance | Pre-existing `extra={"message": ...}` collision in `registry.py:150` (latent since 21b2cee, March 2026). Renderer three-state classification (success / platform_fault / l1_verdict_missing). |
| `7f23495` | test(cap7/l1): integration test for L1 completion via platform-as-harness | Canonical exit-criteria test + three narrower checks. |

## Pre-flight verification outputs

### 1. CLI plumbing path — CLEAN, additive only
- `PlatformRunner.run_single_evaluation` and `invoke_cap7` already accept `layers=`. `BatchRunner.run_batch` did not — added pass-through (`layers: list[str] | None = None`).
- Default behavior (no flag → `layers=None` → `DEFAULT_LAYERS=("L1",)`) unchanged.

### 2. Manifest layer-execution evidence — CLEAN with framing correction
Evidence is split across two artifacts:
- `reports/batch_runs/<batch>/cases/<case_id>/events.jsonl` → sub-capability boundary events.
- `reports/single_eval/<case_id>/manifest.json` → `verdict.layers_requested`, `verdict.layer_stats`, `verdict.sentence_results`.
- The per-case batch manifest is envelope-only; case_id == manifest_id confirmed.
- F20 forward: single_eval manifests are keyed on case_id; same case_id in a later batch overwrites. Acceptable for the sync flow (Makefile invokes renderer immediately after batch); future async work needs to handle.

### 3. Renderer pattern — DIVERGENCE from packet's framing
Codebase uses **Rich Console** + `console.export_text(clear=False)` / `console.export_html()`, NOT Jinja2. New renderer mirrors this pattern exactly: `Console(record=True, force_terminal=True)`, six `_render_*` helpers, dual export. Architect chat ratified.

## Test count delta

977 (post-Commit-1 baseline) → **995** (+18 net). All 18 new tests in this PR.

| File | Tests added |
|---|---|
| `tests/calibration/test_layer_verification_renderer.py` | 14 |
| `tests/calibration/test_l1_completion_integration.py` | 4 |

Full suite: `995 passed in 169s`.

## `make verify-l1` — full RAGTruth-50

```json
{
  "layer": "L1",
  "benchmark": "ragtruth_50",
  "verdict": "PASS",
  "metrics": {
    "detection_rate": 0.0726,
    "precision": 1.0,
    "recall": 0.0772,
    "f1": 0.1433,
    "tp": 22, "fp": 0, "tn": 18, "fn": 263,
    "total_sentences": 303,
    "total_responses": 50
  },
  "case_inclusion": { "included": 50, "total": 50, "excluded": 0, "excluded_cases": [] },
  "findings": [
    "Precision 1.0000 ≥ target 1.0000 — every L1-cleared sentence is correctly grounded (22 TP, 0 FP).",
    "Detection rate 0.0726 within tolerance [0.0690, 0.0790]."
  ]
}
```

Matches the dropped commit's earlier empirical result (`7.26% / 100% / 22 TP / 0 FP / 303 sentences`) — the platform-as-harness flow reproduces the bypass-flow numbers exactly. Algorithm correctness preserved through instrumentation.

Report files: `reports/verifications/l1_ragtruth_50_2026-04-28T001740/{verification_report.html, verification_report.md, verification_summary.json}`.

## `make demo` and `make demo-batch-quick` regression checks

Both still work, default flow unaffected by `--isolate-layer` plumbing:
- `make demo` — `status: SUCCESS, duration: 3.92s, artifacts → reports/demos/2026-04-28T002441`.
- `make demo-batch-quick` — 10/10 SUCCESS through the unchanged DEFAULT_LAYERS path.

## Sample sub-capability events (ragtruth_0, full RAGTruth-50 run)

```jsonl
{"event": "sub_capability_skipped", "capability_id": "CAP-7", "sub_capability_id": "l1_input_preparation", "reason": "sentence_segmentation_shared_across_layers"}
{"event": "sub_capability_started", "capability_id": "CAP-7", "sub_capability_id": "l1_substring_matching"}
{"event": "sub_capability_completed", "capability_id": "CAP-7", "sub_capability_id": "l1_substring_matching", "duration_ms": 60.20, "status": "success"}
{"event": "sub_capability_skipped", "capability_id": "CAP-7", "sub_capability_id": "l1_aggregation", "reason": "interleaved_with_substring_matching_loop"}
{"event": "sub_capability_skipped", "capability_id": "CAP-7", "sub_capability_id": "l1_result_emission", "reason": "no_discrete_emit_step_layer_stats_flow_through_hallucination_result"}
```

All four boundaries fire with explicit reasons on the soft three.

## CLI invocation log — `--isolate-layer L1` plumbing confirmed

Verified end-to-end via `test_l1_meets_all_four_exit_criteria_via_platform`:
- `tools/run_batch_evaluation.py --benchmark ragtruth_5 --isolate-layer L1` → exit 0
- Each per-case CAP-5 manifest carries `verdict.layers_requested == ["L1"]`
- Each case's `verdict.layer_stats["L2"] == 0`, `["L3_deberta"] == 0`, `["L4_supported"] == 0`, `["L4_unsupported"] == 0`
- Each per-case `events.jsonl` carries the four L1 boundary events

## Slice strategy chosen — Option 1 (registered `ragtruth_5`)

Registry `ragtruth_5` adds a single factory closure (`_build_ragtruth_5`) and one new JSON file (`datasets/benchmarks/ragtruth/ragtruth_5_benchmark.json` with `response_ids: ["0","1","2","3","4"]`). Bounded scope per the brief — same shape as `ragtruth_50`, no infrastructure changes. Option 2 (fixture batch_run) was the documented fallback and was not needed.

## Surprises and forward findings

### Pre-flight surprises

- Pre-flight 3 surfaced that the existing report uses **Rich Console**, not Jinja2 as the packet implied. Architect chat ratified mirror-the-Rich-pattern; renderer follows the existing convention exactly.
- Pre-flight 2 found that per-layer verdict evidence lives in `reports/single_eval/<case_id>/manifest.json` (CAP-5 path), not in the batch_runs case manifest (envelope-only). Architect chat ratified reading both artifact sources.
- The CAP-7 wrapper needed a small additive change to surface `sentence_results` and `total_sentences` in the verdict dict — without these, the renderer couldn't compute sentence-level metrics without re-invoking `check_hallucination` (which would violate the platform-as-harness rule). Architect chat anticipated this in the pre-flight resolution ("verdict.sentence_results if exposed").

### Pre-existing bug surfaced (Commit 3 of 4)

`src/llm_judge/datasets/registry.py:147-152` had `extra={"message": sw.message}` — collides with Python's `LogRecord.message` built-in. Latent since `21b2cee` (March 2026); ragtruth cases 18-23 trigger `_check_security` (cases 0-9 don't, which is why prior smoke tests on `--limit 10` never surfaced it). One-line rename to `warning_message` fixes it.

### Forward findings recorded

- **F20**: `reports/single_eval/<case_id>/manifest.json` is keyed on case_id, not batch_id — same case_id in a later batch overwrites. Acceptable for sync renderer invocation; future async verification work needs to handle.
- **F23**: `extra={"message": ...}` is a footgun in any module using stdlib logging with `extra=`. A sweep packet should grep for `extra=.*message` and add a structured-logger contract test asserting no `extra` dict carries a `LogRecord`-reserved key.
- **F24**: platform smoke tests don't exercise the security-warning path; RAGTruth-50 was the first run to surface this gap.

## Test plan

- [x] All 6 instrumentation tests from Commit 1 still pass post-reset (`977 baseline maintained`)
- [x] All 14 renderer tests pass (verdict logic, classification, end-to-end on `ragtruth_5`, three-state fault tolerance)
- [x] All 4 integration tests pass (algorithm regression, DEFAULT_LAYERS, instrumentation function-level, full platform exit-criteria)
- [x] Full pytest suite: 995 passed
- [x] `make verify-l1` on full RAGTruth-50: PASS (7.26% / 100%)
- [x] `make demo` regression check: SUCCESS
- [x] `make demo-batch-quick` regression check: 10/10 SUCCESS, default path unchanged
- [x] `--isolate-layer L1` plumbing verified end-to-end (events.jsonl + CAP-5 manifest)
- [x] Pre-existing logging bug fixed; cases 18-23 now flow through CAP-1 successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)
