### PR TITLE
L1-Pkt-2: combined Layer 1 cleanup (closes CP-F4 + CP-F5 + CP-F14)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,12 +58,26 @@ defense-in-depth: any envelope construction that bypasses
 direct-construction call sites) still refuses to sign with the development
 default in production mode.
 
+## Layer vocabulary alignment
+
+`validate_configuration()` runs `validate_layer_vocabulary()` after the
+HMAC-mode check. The cascade-layer string set declared in
+`wrappers.VALID_LAYERS` plus `configuration.STUB_LAYERS` must equal the
+`--isolate-layer` choice list accepted by `tools/run_batch_evaluation.py`
+(`L1`, `L2`, `L3`, `L4`, `L5`); a mismatch raises `ConfigurationError` at
+startup.
+
+`L5` is in the argparse choices and in `STUB_LAYERS` but not yet in
+`VALID_LAYERS` — argparse keeps it stable across the level-by-level arc,
+`invoke_cap7` rejects it as not-yet-wired. Capturing the gap in
+`STUB_LAYERS` makes the asymmetry a documented architecture decision
+rather than silent drift. Wiring a stub layer is an explicit move from
+`STUB_LAYERS` to `VALID_LAYERS`.
+
 ## Future extensions
 
 `validate_configuration()` is the platform's startup-time configuration
 surface. Subsequent packets absorb additional checks here:
 
-- Layer vocabulary alignment between `wrappers.DEFAULT_LAYERS` and
-  `eval/run.py` argparse choices (CP-F4, target packet L1-Pkt-2).
 - Artifact root writability (`runs_root`, `transient_root`).
 - Governance preflight reachability (`rubrics/registry.yaml`).

--- a/src/llm_judge/control_plane/configuration.py
+++ b/src/llm_judge/control_plane/configuration.py
@@ -9,11 +9,20 @@ Currently absorbed checks:
   - HMAC key in production mode (closes CP-F2 and CP-F11): when
     ``LLM_JUDGE_MODE=production``, ``LLM_JUDGE_CONTROL_PLANE_HMAC_KEY``
     must be set; otherwise :class:`ConfigurationError` is raised.
+  - Layer vocabulary alignment (closes CP-F4): the cascade-layer
+    string set declared in
+    :data:`llm_judge.control_plane.wrappers.VALID_LAYERS` plus
+    :data:`STUB_LAYERS` must equal the ``--isolate-layer`` choice list
+    accepted by ``tools/run_batch_evaluation.py``. ``L5`` is in the
+    argparse choices and in :data:`STUB_LAYERS` but not yet in
+    ``VALID_LAYERS`` — argparse keeps it stable across the
+    level-by-level arc, ``invoke_cap7`` rejects it as unwired (see
+    ``tools/run_batch_evaluation.py`` ``--isolate-layer`` help text).
+    Capturing the gap in :data:`STUB_LAYERS` makes the asymmetry a
+    documented architecture decision rather than silent drift.
 
 Expected future extensions (declared here for governance continuity;
 not yet implemented):
-  - Layer vocabulary alignment between :mod:`wrappers` ``DEFAULT_LAYERS``
-    and ``eval/run.py`` argparse choices (CP-F4, target packet L1-Pkt-2).
   - Artifact root validation: writability of ``runs_root`` /
     ``transient_root`` at startup rather than at first persistence.
   - Governance preflight reachability: ``rubrics/registry.yaml`` exists
@@ -49,6 +58,19 @@ _HMAC_ENV_VAR = "LLM_JUDGE_CONTROL_PLANE_HMAC_KEY"
 _DEFAULT_MODE = "development"
 _VALID_MODES = frozenset({"development", "production"})
 
+STUB_LAYERS: frozenset[str] = frozenset({"L5"})
+"""Cascade-layer identifiers that are accepted at the argparse boundary
+but not yet wired into ``invoke_cap7``. Listed here so layer-vocabulary
+alignment treats the gap as documented architecture rather than drift."""
+
+_ARGPARSE_LAYER_CHOICES: frozenset[str] = frozenset({"L1", "L2", "L3", "L4", "L5"})
+"""The cascade-layer choices that ``tools/run_batch_evaluation.py``
+``--isolate-layer`` accepts. Mirrored here so :func:`validate_layer_vocabulary`
+can verify alignment without importing the script. A separate test
+(``tests/control_plane/test_configuration.py``) loads the actual parser
+and asserts the live choices equal this set, catching drift in the tool
+file even when configuration.py is unchanged."""
+
 _resolved_mode: str | None = None
 
 
@@ -65,16 +87,50 @@ def _read_mode() -> str:
     return candidate
 
 
+def validate_layer_vocabulary() -> None:
+    """Validate cascade-layer vocabulary alignment at startup.
+
+    The ``--isolate-layer`` argparse choice list in
+    ``tools/run_batch_evaluation.py`` MUST equal
+    :data:`llm_judge.control_plane.wrappers.VALID_LAYERS` ∪
+    :data:`STUB_LAYERS`. The split distinguishes wired layers (rejected
+    by ``invoke_cap7`` only when truly unknown) from stub layers
+    (rejected by ``invoke_cap7`` as not-yet-implemented). When a stub
+    layer becomes wired, the developer moves it from :data:`STUB_LAYERS`
+    into ``VALID_LAYERS``; this function verifies the split stays
+    coherent so neither set silently drifts.
+
+    Raises:
+        ConfigurationError: ``VALID_LAYERS ∪ STUB_LAYERS`` does not
+            equal the argparse choice set declared here.
+    """
+    from llm_judge.control_plane.wrappers import VALID_LAYERS
+
+    expected = VALID_LAYERS | STUB_LAYERS
+    if _ARGPARSE_LAYER_CHOICES != expected:
+        raise ConfigurationError(
+            f"layer vocabulary misalignment: argparse choices "
+            f"{sorted(_ARGPARSE_LAYER_CHOICES)} != "
+            f"VALID_LAYERS ∪ STUB_LAYERS {sorted(expected)}; "
+            f"if wiring a stub, move it from STUB_LAYERS into "
+            f"VALID_LAYERS; if adding a layer, update both "
+            f"_ARGPARSE_LAYER_CHOICES and the choice list in "
+            f"tools/run_batch_evaluation.py"
+        )
+
+
 def validate_configuration() -> None:
     """Validate platform configuration; raise on production gaps.
 
     Called once near the top of ``PlatformRunner.__init__``. After a
     successful return, :func:`get_mode` reflects the validated mode for
     the lifetime of the process (or until :func:`_reset_for_tests` runs).
+    Validators run in sequence: HMAC mode first, then layer vocabulary.
 
     Raises:
-        ConfigurationError: production mode without an HMAC key, or an
-            unknown ``LLM_JUDGE_MODE`` value.
+        ConfigurationError: production mode without an HMAC key, an
+            unknown ``LLM_JUDGE_MODE`` value, or layer vocabulary
+            misalignment (see :func:`validate_layer_vocabulary`).
     """
     global _resolved_mode
 
@@ -95,6 +151,8 @@ def validate_configuration() -> None:
             env_var=_HMAC_ENV_VAR,
             hint="set env var for non-development use",
         )
+
+    validate_layer_vocabulary()
 
     _resolved_mode = mode
 

--- a/src/llm_judge/control_plane/runner.py
+++ b/src/llm_judge/control_plane/runner.py
@@ -191,11 +191,6 @@ class PlatformRunner:
         The ``"latest"`` sentinel is resolved against
         ``rubrics/registry.yaml`` at the wrapper boundary so
         downstream loaders see a concrete version.
-
-        Future: CP-1c-b.2 will tighten binding enforcement (prompt
-        loading honors rubric_id, schema enforcement becomes
-        mandatory on the eval/run.py path, governance preflight
-        rejects ungoverned rubric_ids).
         """
         active_layers = list(layers) if layers else list(DEFAULT_LAYERS)
         runs_root = output_dir if output_dir is not None else self._runs_root

--- a/src/llm_judge/control_plane/types.py
+++ b/src/llm_judge/control_plane/types.py
@@ -16,6 +16,7 @@ __all__ = [
     "ConfigurationError",
     "Integrity",
     "MissingProvenanceError",
+    "RubricNotInRegistryError",
     "SingleEvaluationRequest",
     "SingleEvaluationResult",
 ]
@@ -33,6 +34,28 @@ class ConfigurationError(Exception):
     an HMAC key is the first instance; subsequent packets extend
     ``validate_configuration()`` to cover layer vocabulary alignment,
     artifact root validation, and governance preflight reachability."""
+
+
+class RubricNotInRegistryError(ValueError):
+    """Raised when ``rubric_store._resolve_version`` is asked for a
+    rubric_id that is absent from ``rubrics/registry.yaml``'s
+    ``latest:`` map.
+
+    Subclasses :class:`ValueError` so existing callers that
+    ``except ValueError:`` around rubric resolution continue to work
+    unchanged; new callers can catch this class specifically when they
+    want to distinguish "unknown rubric" from other ValueError causes
+    without inspecting the message string.
+
+    Scope note: the sibling raise site at
+    ``rubric_store._resolve_version`` line 106-109 ("invalid latest
+    version for rubric '<id>': <value>") describes a known rubric
+    whose ``latest:`` pointer is empty/whitespace — registry
+    malformation rather than a registry-membership gap. That case
+    remains a plain :class:`ValueError`; it is closer to
+    :class:`llm_judge.rubric_store.RubricSchemaError`'s territory than
+    to :class:`RubricNotInRegistryError`'s and may be migrated
+    separately in a future packet."""
 
 
 class Integrity(BaseModel):

--- a/src/llm_judge/rubric_store.py
+++ b/src/llm_judge/rubric_store.py
@@ -17,6 +17,7 @@ from typing import Any
 import yaml
 from pydantic import ValidationError
 
+from llm_judge.control_plane.types import RubricNotInRegistryError
 from llm_judge.rule_plan_yaml import RubricRegistryConfig, rubric_definition_model
 
 
@@ -92,14 +93,21 @@ def _resolve_version(rubric_id: str) -> str:
     """Resolve the latest version for ``rubric_id`` from
     ``rubrics/registry.yaml``.
 
-    Raises :class:`ValueError` (a plain ``ValueError``, not
-    ``RubricSchemaError``) if the registry has no latest pointer
-    for this rubric — that is a governance gap, not a schema
-    malformation.
+    Raises :class:`llm_judge.control_plane.types.RubricNotInRegistryError`
+    (a subclass of :class:`ValueError`) if ``rubric_id`` is absent from
+    the registry's ``latest:`` map — a registry-membership gap, neither
+    a schema malformation nor a malformed pointer for a known rubric.
+
+    Raises plain :class:`ValueError` if the rubric IS registered but its
+    ``latest:`` pointer is empty or whitespace-only — registry
+    malformation for a known rubric, closer to
+    :class:`RubricSchemaError`'s territory than to
+    :class:`RubricNotInRegistryError`'s. Migration of that case is
+    deferred to a future packet.
     """
     registry = _load_registry()
     if rubric_id not in registry.latest:
-        raise ValueError(
+        raise RubricNotInRegistryError(
             f"Rubric not registered in registry.yaml latest: {rubric_id}"
         )
     v = registry.latest[rubric_id]

--- a/tests/control_plane/test_configuration.py
+++ b/tests/control_plane/test_configuration.py
@@ -1,15 +1,19 @@
 """Unit tests for control_plane.configuration startup validation.
 
-Covers CP-F2 (HMAC default-key fallback hardening) and CP-F11
-(no startup-time configuration validation) closure mechanisms.
+Covers CP-F2 (HMAC default-key fallback hardening), CP-F11
+(no startup-time configuration validation), and CP-F4 (layer vocabulary
+alignment via :func:`validate_layer_vocabulary`) closure mechanisms.
 """
 
 from __future__ import annotations
 
+import importlib.util
+from pathlib import Path
+
 import pytest
 from structlog.testing import capture_logs
 
-from llm_judge.control_plane import configuration
+from llm_judge.control_plane import configuration, wrappers
 from llm_judge.control_plane.types import ConfigurationError
 
 
@@ -120,3 +124,107 @@ def test_get_mode_before_validation_unknown_mode_raises(
     monkeypatch.setenv("LLM_JUDGE_MODE", "staging")
     with pytest.raises(ConfigurationError):
         configuration.get_mode()
+
+
+# ---------------------------------------------------------------------------
+# CP-F4: validate_layer_vocabulary
+# ---------------------------------------------------------------------------
+
+
+def test_validate_layer_vocabulary_aligned_passes() -> None:
+    """At master HEAD, ``VALID_LAYERS ∪ STUB_LAYERS`` equals the
+    declared argparse choice set; the validator returns silently."""
+    configuration.validate_layer_vocabulary()
+
+
+def test_validate_layer_vocabulary_argparse_drift_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A change to the declared argparse choices that no longer matches
+    ``VALID_LAYERS ∪ STUB_LAYERS`` raises ConfigurationError."""
+    monkeypatch.setattr(
+        configuration,
+        "_ARGPARSE_LAYER_CHOICES",
+        frozenset({"L1", "L2", "L3", "L4"}),  # dropped L5
+    )
+    with pytest.raises(ConfigurationError) as excinfo:
+        configuration.validate_layer_vocabulary()
+    assert "argparse choices" in str(excinfo.value)
+    assert "L5" in str(excinfo.value)
+
+
+def test_validate_layer_vocabulary_valid_layers_drift_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Wiring a new layer in ``VALID_LAYERS`` without updating
+    ``_ARGPARSE_LAYER_CHOICES`` raises ConfigurationError."""
+    monkeypatch.setattr(
+        wrappers,
+        "VALID_LAYERS",
+        frozenset({"L1", "L2", "L3", "L4", "L6"}),  # added L6
+    )
+    with pytest.raises(ConfigurationError) as excinfo:
+        configuration.validate_layer_vocabulary()
+    assert "L6" in str(excinfo.value)
+
+
+def test_validate_layer_vocabulary_stub_layers_drift_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Removing L5 from ``STUB_LAYERS`` without also removing it from
+    the argparse choice set raises ConfigurationError."""
+    monkeypatch.setattr(configuration, "STUB_LAYERS", frozenset())
+    with pytest.raises(ConfigurationError) as excinfo:
+        configuration.validate_layer_vocabulary()
+    assert "L5" in str(excinfo.value)
+
+
+def test_validate_configuration_calls_layer_vocabulary_validator_in_sequence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``validate_configuration`` runs HMAC-mode validation first, then
+    layer vocabulary validation. A vocabulary fault surfaces only after
+    HMAC has been checked, and the cached mode is NOT set when vocabulary
+    validation fails (fail-closed)."""
+    monkeypatch.setattr(configuration, "STUB_LAYERS", frozenset())
+    with pytest.raises(ConfigurationError):
+        configuration.validate_configuration()
+    # Mode cache must remain unset because validate_configuration aborted.
+    assert configuration._resolved_mode is None
+
+
+def test_validate_configuration_production_hmac_fault_skips_vocabulary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If HMAC validation fails in production mode, vocabulary
+    validation is never reached; both checks running unconditionally
+    would lose the sequencing invariant."""
+    monkeypatch.setenv("LLM_JUDGE_MODE", "production")
+    # Break vocabulary too — but HMAC failure should fire first.
+    monkeypatch.setattr(configuration, "STUB_LAYERS", frozenset())
+    with pytest.raises(ConfigurationError) as excinfo:
+        configuration.validate_configuration()
+    assert "LLM_JUDGE_CONTROL_PLANE_HMAC_KEY" in str(excinfo.value)
+
+
+def test_argparse_choices_match_declared_set() -> None:
+    """The ``--isolate-layer`` choice list in
+    ``tools/run_batch_evaluation.py`` MUST equal the set declared in
+    :data:`configuration._ARGPARSE_LAYER_CHOICES`. Catches drift in the
+    tool file even when configuration.py is unchanged.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    tool_path = repo_root / "tools" / "run_batch_evaluation.py"
+    spec = importlib.util.spec_from_file_location(
+        "_l1pkt2_run_batch_evaluation", tool_path
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    parser = module._build_argparser()
+    isolate_action = next(
+        action for action in parser._actions if action.dest == "isolate_layer"
+    )
+    assert isolate_action.choices is not None
+    assert frozenset(isolate_action.choices) == configuration._ARGPARSE_LAYER_CHOICES

--- a/tests/control_plane/test_rubric_not_in_registry_error.py
+++ b/tests/control_plane/test_rubric_not_in_registry_error.py
@@ -1,0 +1,64 @@
+"""Unit tests for the CP-F14 closure: RubricNotInRegistryError.
+
+The new exception lives in :mod:`llm_judge.control_plane.types` and is
+raised by :func:`llm_judge.rubric_store._resolve_version` when a
+rubric_id is absent from ``rubrics/registry.yaml``'s ``latest:`` map
+(the "unknown rubric_id" case at rubric_store.py:102-104).
+
+The sibling raise at rubric_store.py:106-109 ("invalid latest version
+for rubric '<id>'") is intentionally NOT migrated in L1-Pkt-2 — that
+case describes registry malformation for a known rubric, which is
+:class:`RubricSchemaError`'s territory rather than
+:class:`RubricNotInRegistryError`'s. Tests below assert this scope
+discipline so a future packet that revisits the secondary raise has a
+clear precedent.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from llm_judge.control_plane.types import RubricNotInRegistryError
+from llm_judge.rubric_store import _resolve_version
+
+
+def test_rubric_not_in_registry_error_subclasses_value_error() -> None:
+    """Subclass relationship preserves backward compatibility for
+    callers that do ``except ValueError`` around rubric resolution."""
+    assert issubclass(RubricNotInRegistryError, ValueError)
+
+
+def test_resolve_version_unknown_rubric_id_raises_specific_subclass() -> None:
+    """Unknown rubric_id raises RubricNotInRegistryError specifically;
+    callers that want type precision can catch the new class without
+    inspecting the message string."""
+    with pytest.raises(RubricNotInRegistryError) as excinfo:
+        _resolve_version("definitely_not_a_real_rubric_id_for_l1_pkt_2")
+    assert "not registered" in str(excinfo.value)
+    assert "definitely_not_a_real_rubric_id_for_l1_pkt_2" in str(excinfo.value)
+
+
+def test_resolve_version_unknown_rubric_id_still_caught_by_value_error() -> None:
+    """Existing ``except ValueError`` callers continue to catch the new
+    exception unchanged. This is the subclass-relationship guarantee
+    that CP-F14 closure depends on for backward compatibility."""
+    with pytest.raises(ValueError):
+        _resolve_version("definitely_not_a_real_rubric_id_for_l1_pkt_2")
+
+
+def test_rubric_not_in_registry_error_in_module_all() -> None:
+    """The exception is exported via :data:`__all__` so external callers
+    can rely on a stable import path
+    ``from llm_judge.control_plane.types import RubricNotInRegistryError``."""
+    from llm_judge.control_plane import types
+
+    assert "RubricNotInRegistryError" in types.__all__
+
+
+def test_rubric_not_in_registry_error_has_docstring() -> None:
+    """The exception class must carry an actionable docstring describing
+    the raise condition and the subclass relationship rationale."""
+    assert RubricNotInRegistryError.__doc__ is not None
+    doc = RubricNotInRegistryError.__doc__
+    assert "registry" in doc.lower()
+    assert "ValueError" in doc

--- a/tests/unit/test_rubric_store.py
+++ b/tests/unit/test_rubric_store.py
@@ -1,5 +1,6 @@
 import pytest
 
+from llm_judge.control_plane.types import RubricNotInRegistryError
 from llm_judge.rubric_store import get_rubric
 
 
@@ -17,5 +18,15 @@ def test_get_rubric_explicit_version() -> None:
 
 
 def test_get_rubric_unknown_raises() -> None:
+    """Backward-compat sentinel: existing ``except ValueError`` callers
+    continue to catch unknown-rubric errors via the subclass
+    relationship (CP-F14)."""
     with pytest.raises(ValueError):
+        get_rubric("does_not_exist")
+
+
+def test_get_rubric_unknown_raises_specific_type() -> None:
+    """CP-F14 type precision: the unknown-rubric raise propagated
+    through ``get_rubric`` is specifically RubricNotInRegistryError."""
+    with pytest.raises(RubricNotInRegistryError):
         get_rubric("does_not_exist")


### PR DESCRIPTION
## L1-Pkt-2 — Combined Layer 1 cleanup

Closes **CP-F4** (layer vocabulary alignment), **CP-F5** (sibling notation drift), **CP-F14** (RubricNotInRegistryError).

CP-F6 and CP-F15 were silently closed by prior packets (Pre-flights 4 and 6 caught them). v1.4 attribution registered. Commits 3 and 5 omitted.

Base: `master` @ `9c145d4` (post-PR #197).

---

## Commits

```
60b500c  feat(control-plane): align layer vocabulary at startup (closes CP-F4)
2e43b02  docs(control-plane): correct sibling notation drift (closes CP-F5)
4b3ef73  feat(control-plane): introduce RubricNotInRegistryError (closes CP-F14)
```

`git diff --stat master`:

```
 docs/configuration.md                              |  18 +++-
 src/llm_judge/control_plane/configuration.py       |  66 +++++++++++-
 src/llm_judge/control_plane/runner.py              |   5 -
 src/llm_judge/control_plane/types.py               |  23 +++++
 src/llm_judge/rubric_store.py                      |  18 +++-
 tests/control_plane/test_configuration.py          | 114 ++++++++++++++++++++-
 tests/control_plane/test_rubric_not_in_registry_error.py |  64 ++++++++++++
 tests/unit/test_rubric_store.py                    |  11 ++
 8 files changed, 300 insertions(+), 19 deletions(-)
```

---

## Pre-flight outcomes (Layer 1 chat checkpoint)

| Pre-flight | Outcome | Disposition |
|---|---|---|
| 1 | Master state PASS — `9c145d4` | proceed |
| 2 | Cascade L5 stub case (cond. 7) | **Option C** — STUB_LAYERS = frozenset({"L5"}) |
| 3 | 3 drift sites cataloged (1 ambiguous) | items 1 & 2 = eval/run.py → tools/run_batch_evaluation.py; item 3 = drop stale "Future:" block |
| 4 | **No drift** (cond. 9) | CP-F6 closed by **PR #192** / `f184df5` (CP-3 batch demo) — Commit 3 omitted |
| 5 | `_resolve_version` at `rubric_store.py:91`; line 102-104 = unknown rubric, line 106-109 = ambiguous | line 102-104 → RubricNotInRegistryError; **line 106-109 stays plain ValueError** (registry-malformation, RubricSchemaError's territory; future packet may migrate) |
| 6 | RubricSchemaError already proper (cond. 12) | CP-F15 closed by **PR #189** / `ccad817` (CP-1c-a rubric governance core) — Commit 5 omitted |

GO received from Layer 1 chat after consolidated checkpoint output.

---

## Commit details

### Commit 1 (60b500c) — CP-F4 vocabulary alignment

- `STUB_LAYERS = frozenset({"L5"})` and `_ARGPARSE_LAYER_CHOICES = frozenset({"L1","L2","L3","L4","L5"})` declared in `configuration.py`.
- `validate_layer_vocabulary()` enforces invariant `_ARGPARSE_LAYER_CHOICES == VALID_LAYERS ∪ STUB_LAYERS`.
- Wired into `validate_configuration()` after HMAC-mode validation.
- Mechanism class transition: layer vocabulary alignment **convention → runtime gate**.
- Module docstring rewritten — moved CP-F4 from "Expected future extensions" into "Currently absorbed checks", using the correct `tools/run_batch_evaluation.py` reference. (Side effect: Pre-flight 3 catalog item #1 fixed in this commit; Commit 2 covers items #2 and #3.)
- 7 new tests in `test_configuration.py` (using `_reset_for_tests()` discipline):
  - `test_validate_layer_vocabulary_aligned_passes`
  - `test_validate_layer_vocabulary_argparse_drift_fails`
  - `test_validate_layer_vocabulary_valid_layers_drift_fails`
  - `test_validate_layer_vocabulary_stub_layers_drift_fails`
  - `test_validate_configuration_calls_layer_vocabulary_validator_in_sequence`
  - `test_validate_configuration_production_hmac_fault_skips_vocabulary` (sequencing invariant)
  - `test_argparse_choices_match_declared_set` (catches drift in tool file even when configuration.py is unchanged — imports the actual `_build_argparser()` via `importlib.util.spec_from_file_location`)

### Commit 2 (2e43b02) — CP-F5 sibling notation drift

- `docs/configuration.md:67` — eval/run.py → tools/run_batch_evaluation.py (replaced future-extension entry with a new "Layer vocabulary alignment" section documenting the now-shipped `validate_layer_vocabulary()` check).
- `src/llm_judge/control_plane/runner.py:195-198` — dropped stale `Future: CP-1c-b.2 will tighten binding enforcement (… eval/run.py path …)` block from `run_single_evaluation` docstring. CP-1c-b.2 has shipped (PR #195); the prose is no longer accurate.
- Pure text correction; no behavioral change.

### Commit 4 (4b3ef73) — CP-F14 RubricNotInRegistryError

- `RubricNotInRegistryError(ValueError)` added to `src/llm_judge/control_plane/types.py` with Sphinx-style docstring + `__all__` membership.
- `src/llm_judge/rubric_store.py:102-104` raise migrated (unknown rubric_id case).
- **Line 106-109 raise intentionally NOT migrated** — it describes registry malformation for a known rubric (empty/whitespace `latest:` pointer). That case is closer to `RubricSchemaError`'s territory than to `RubricNotInRegistryError`'s; future packet may migrate it separately. Updated `_resolve_version` docstring describes both raises.
- `_resolve_version` import: `from llm_judge.control_plane.types import RubricNotInRegistryError` (top-level; no circular import — Pre-flight 5 verified types.py and envelope.py don't import from rubric_store).
- Subclass-of-ValueError: existing `except ValueError:` callers continue to catch the new exception unchanged. **Backward-compat sentinel test** (`test_get_rubric_unknown_raises`) preserved alongside a new type-precision test (`test_get_rubric_unknown_raises_specific_type`).
- Mechanism class transition: rubric resolution exception specificity **convention → runtime gate**.
- 5 new tests in `tests/control_plane/test_rubric_not_in_registry_error.py` + 1 strengthened test in `tests/unit/test_rubric_store.py`.

---

## Test results

| | Count |
|---|---|
| Master baseline | 1012 collected |
| HEAD (this PR) | 1025 collected |
| Net delta | **+13 tests** |

Per-commit pytest green at each commit boundary. The full preflight chain (ruff + typecheck + pytest + rules-validate + baseline-validate + pr-gate + drift-check) passed.

```
======================================
Preflight SUCCESS — ready to push.
======================================
```

Demo runs at HEAD:
- `make demo` — SUCCESS, 4 capabilities (CAP-1 → CAP-2 → CAP-7 → CAP-5) all green.
- `make demo-batch-quick` — all 10 ragtruth cases SUCCESS.
- `make verify-l1` — verdict **PASS** (Precision 1.0000 ≥ target 1.0000; Detection rate 0.0726 within tolerance [0.0690, 0.0790]).

Subclass relationship verification: the existing `test_get_rubric_unknown_raises` (asserts `pytest.raises(ValueError)`) continues to pass at HEAD, confirming the backward-compat guarantee. `test_wrappers_version_resolution.py::test_latest_unregistered_rubric_raises` likewise passes via the subclass relationship.

---

## v1.4 / v1.5 attributions

- **CP-F6** (CAP-5 wrapper docstring drift): silently closed by **PR #192** / `f184df5` (CP-3 batch demonstration with sub-capability instrumentation). Pre-flight 4 caught it.
- **CP-F15** (RubricSchemaError documentation): silently closed by **PR #189** / `ccad817` (CP-1c-a rubric governance core). Pre-flight 6 caught it.

---

## New finding for gap analysis

**CP-F22 candidate** — Rubric exception family split across two modules:
- `src/llm_judge/rubric_store.py:23` — `RubricSchemaError(ValueError)`
- `src/llm_judge/control_plane/types.py` — `RubricNotInRegistryError(ValueError)`

Both rubric-domain exceptions; both subclass `ValueError`; live in different modules per the brief's architectural decision 4. Future cleanup packet may colocate them. Out of scope for L1-Pkt-2.

---

## Contract document impacts (queued for v4 revision)

External Contract v3.2 stays at Active state through this PR. Two impacts queued for v4:
1. v3.2 §4.3(b) and §5.3 reference `ValueError` raised from `rubric_store._resolve_version`. v4 should reference `RubricNotInRegistryError` with subclass-of-ValueError note.
2. v3.2 §4.6 (or equivalent error-class section) does not document `RubricSchemaError`; v4 should add it to the documented exception taxonomy.

---

## F19 multi-commit deviation pattern (per L1-Pkt-1 precedent)

`make git-ship` does `git add .` and supports a single commit message — incompatible with multi-commit bisectable structure. This PR uses the substitute pattern:
- Targeted `git add <files>` per commit (no `git add .`)
- Per-commit `git commit -m "..."`
- `make preflight` before push (gate honored)
- Hand-driven `git push`

Documented as expected per F19 (architect chat disposition still pending).

---

## Discipline confirmations

- ☑ Layer 1 chat review checkpoint executed; GO received before Commits 2 & 4.
- ☑ Multi-commit deviation pattern per F19.
- ☑ New tests follow `_reset_for_tests()` discipline.
- ☑ Subclass relationship verified — existing ValueError-catching tests still pass.
- ☑ Line `rubric_store.py:106-109` raise intentionally NOT migrated (precision per Layer 1 chat disposition).
- ☑ External Contract document NOT modified (v3.2 stays Active; impacts queued for v4).
- ☑ `make preflight` shows "Preflight SUCCESS — ready to push".
- ☑ No platform capability bypass.
- ☑ CP-F20 cluster expanded (rubric_store now imports `RubricNotInRegistryError` from `control_plane/types`); no new circular import.

---

## Test plan

- [ ] CI on this PR is green
- [ ] Reviewer confirms Pre-flight 4 + 6 attributions land in gap analysis v1.5
- [ ] Reviewer confirms CP-F22 candidate registered in v1.5
- [ ] Layer 1 chat verifies before merge
