### PR TITLE
L1-Pkt-B: substrate + timeout + capability registry (closes CP-F9, CP-F12; partial CP-F8)

### DIFF
--- a/src/llm_judge/control_plane/batch_aggregation.py
+++ b/src/llm_judge/control_plane/batch_aggregation.py
@@ -19,11 +19,17 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field
 
 from llm_judge.control_plane.batch_runner import BatchResult
+from llm_judge.control_plane.capability_registry import CAPABILITY_REGISTRY
 
-# The four vertical capabilities the Runner orchestrates today.
-# CAP-7 stays capability-level (D1: no layer cascade refactor); the
-# other three carry sub-capability instrumentation.
-VERTICAL_CAPABILITIES: tuple[str, ...] = ("CAP-1", "CAP-2", "CAP-7", "CAP-5")
+# Vertical capabilities derived from CAPABILITY_REGISTRY (CP-F9
+# closure, L1-Pkt-B). Adding a capability requires a registry
+# change; this rollup picks it up automatically rather than via a
+# parallel hard-coded enumeration. CAP-7 stays capability-level
+# (D1: no layer cascade refactor); the other three carry
+# sub-capability instrumentation.
+VERTICAL_CAPABILITIES: tuple[str, ...] = tuple(
+    spec.capability_id for spec in CAPABILITY_REGISTRY
+)
 
 # Horizontal capabilities reported as 0/N until they are wired (D4).
 HORIZONTAL_CAPABILITIES: tuple[str, ...] = ("CAP-6", "CAP-10")

--- a/src/llm_judge/control_plane/capability_registry.py
+++ b/src/llm_judge/control_plane/capability_registry.py
@@ -1,0 +1,87 @@
+"""Capability registry — runtime catalog of orchestrated capabilities (CP-F9 closure).
+
+Layer 1's per-case orchestration runs CAP-1 → [CAP-2, CAP-7] → CAP-5.
+Prior to L1-Pkt-B that sequence was hard-coded inside
+:meth:`PlatformRunner.run_single_evaluation` with no module-level
+record. This module records the sequence as ``CAPABILITY_REGISTRY``:
+a frozen tuple of :class:`CapabilitySpec` entries that the
+orchestrator iterates, dispatching to the right wrapper based on
+``capability_id``.
+
+Each spec carries metadata only — capability id, sequence position,
+and the operational timeout in seconds. Callable references stay
+in :mod:`llm_judge.control_plane.runner` because the four capabilities
+have heterogeneous signatures and conditional dispatch on CAP-1
+failure / aggregation between CAP-7 and CAP-5; uniform-signature
+refactor is out of scope for L1-Pkt-B.
+
+The registry is strict-from-day-one: it lists exactly the four
+capabilities currently orchestrated. Adding a fifth capability is
+a registry change plus a new dispatch arm in the orchestrator.
+
+Initial timeouts are conservative starting points derived from a
+50-case ``make verify-l1`` run on master @ 85c7e5c (Pre-flight 3
+of L1-Pkt-B):
+
+* CAP-1, CAP-2, CAP-5: P99 < 50 ms; timeout set to 5 s (>100x P99).
+* CAP-7: P99 ≈ 3925 ms (driven by case-0 LLM warm-up); timeout
+  set to 30 s — extra headroom over the strict 5x rule for
+  warm-up volatility.
+
+Sample is small (test runs only, not production traffic). Values
+are operational starting points; tune post-deployment as production
+latency data accumulates.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = [
+    "CAPABILITY_REGISTRY",
+    "CapabilitySpec",
+    "get_spec",
+]
+
+
+class CapabilitySpec(BaseModel):
+    """One capability's runtime metadata.
+
+    Frozen Pydantic; treat instances as values. The orchestrator
+    looks up the matching wrapper by ``capability_id`` and uses
+    ``timeout_seconds`` to configure the TimeoutGuardrail for
+    each invocation.
+
+    ``sequence_position`` is redundant with the registry tuple's
+    index but preserved as an explicit field so the contract is
+    self-describing: a spec viewed in isolation still records where
+    it sits in the chain.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    capability_id: str = Field(..., min_length=1)
+    sequence_position: int = Field(..., ge=0)
+    timeout_seconds: float = Field(..., gt=0)
+
+
+CAPABILITY_REGISTRY: tuple[CapabilitySpec, ...] = (
+    CapabilitySpec(capability_id="CAP-1", sequence_position=0, timeout_seconds=5.0),
+    CapabilitySpec(capability_id="CAP-2", sequence_position=1, timeout_seconds=5.0),
+    CapabilitySpec(capability_id="CAP-7", sequence_position=2, timeout_seconds=30.0),
+    CapabilitySpec(capability_id="CAP-5", sequence_position=3, timeout_seconds=5.0),
+)
+
+
+def get_spec(capability_id: str) -> CapabilitySpec:
+    """Return the spec for ``capability_id``.
+
+    Raises :class:`KeyError` if no entry matches. Linear scan — the
+    registry is small (single-digit) and fixed at import time, so
+    the cost is negligible and a parallel dict-by-id index would be
+    duplicated state.
+    """
+    for spec in CAPABILITY_REGISTRY:
+        if spec.capability_id == capability_id:
+            return spec
+    raise KeyError(f"No CapabilitySpec for capability_id={capability_id!r}")

--- a/src/llm_judge/control_plane/guardrails/__init__.py
+++ b/src/llm_judge/control_plane/guardrails/__init__.py
@@ -1,0 +1,39 @@
+"""Guardrails — operational substrate around capability invocations (CP-F8 closure).
+
+Layer 1's orchestrator wraps each capability invocation with the
+substrate provided here. Concrete guardrails (timeout in L1-Pkt-B;
+rate limit / circuit breaker / kill switch in future packets)
+register against the substrate and have their ``pre_call`` and
+``post_call`` hooks fired around every invocation.
+
+Public API:
+
+* :class:`Guardrail` — base class for concrete guardrails.
+* :class:`GuardrailDecision` — Allow/Deny return shape.
+* :class:`GuardrailContext` — per-invocation state passed to hooks.
+* :func:`guardrail_context` — context manager that runs hooks.
+* :func:`register_guardrail` — adds a guardrail to the global
+  registry consumed by ``guardrail_context``.
+* :func:`_reset_for_tests` — clears the registry; tests use it to
+  isolate module-level state per the L1-Pkt-1 pattern.
+"""
+
+from __future__ import annotations
+
+from llm_judge.control_plane.guardrails.substrate import (
+    Guardrail,
+    GuardrailContext,
+    GuardrailDecision,
+    _reset_for_tests,
+    guardrail_context,
+    register_guardrail,
+)
+
+__all__ = [
+    "Guardrail",
+    "GuardrailContext",
+    "GuardrailDecision",
+    "_reset_for_tests",
+    "guardrail_context",
+    "register_guardrail",
+]

--- a/src/llm_judge/control_plane/guardrails/__init__.py
+++ b/src/llm_judge/control_plane/guardrails/__init__.py
@@ -28,12 +28,22 @@ from llm_judge.control_plane.guardrails.substrate import (
     guardrail_context,
     register_guardrail,
 )
+from llm_judge.control_plane.guardrails.timeout import TimeoutGuardrail
 
 __all__ = [
     "Guardrail",
     "GuardrailContext",
     "GuardrailDecision",
+    "TimeoutGuardrail",
     "_reset_for_tests",
     "guardrail_context",
     "register_guardrail",
 ]
+
+
+# Production wiring: TimeoutGuardrail fires for every capability
+# invocation through the runner (CP-F12 closure, L1-Pkt-B Commit 5).
+# Tests that need an empty registry call _reset_for_tests() and
+# either pass guardrails= explicitly to guardrail_context() or
+# re-register a tailored set.
+register_guardrail(TimeoutGuardrail())

--- a/src/llm_judge/control_plane/guardrails/substrate.py
+++ b/src/llm_judge/control_plane/guardrails/substrate.py
@@ -1,0 +1,259 @@
+"""Guardrail substrate primitives (CP-F8 scaffold, L1-Pkt-B Commit 3).
+
+Provides the framework that concrete guardrails plug into:
+
+* :class:`Guardrail` — base class. Subclasses override ``pre_call``
+  and/or ``post_call``; both default to Allow.
+* :class:`GuardrailDecision` — Allow/Deny return shape with a
+  reason string and structured context for telemetry. Modify is
+  reserved for a future packet (Decision 3c, L1-Pkt-B).
+* :class:`GuardrailContext` — per-invocation state passed to hooks.
+  Mutable so guardrails can carry handles between ``pre_call`` and
+  ``post_call`` (e.g. the timeout guardrail records a start time).
+* :func:`guardrail_context` — context manager. Iterates registered
+  guardrails: pre-call before yielding, post-call after. Any Deny
+  decision raises :class:`GuardrailDeniedError`. Telemetry events
+  ``guardrail.pre_call`` and ``guardrail.post_call`` are emitted
+  for every hook invocation. Events ship through the existing
+  structlog/event-bus path (ungoverned vocabulary in this packet;
+  CP-F7 + CP-F13 closure absorbs into the platform-wide event
+  vocabulary in a future packet).
+* :func:`register_guardrail` — adds a guardrail to the
+  module-level registry consumed by ``guardrail_context``.
+
+This commit ships the substrate as a pure scaffold — no guardrails
+registered, orchestrator does not yet wrap iteration. Commit 4
+wires the substrate into the orchestrator; Commit 5 registers the
+first concrete guardrail (TimeoutGuardrail).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from llm_judge.control_plane.capability_registry import CapabilitySpec
+from llm_judge.control_plane.observability import emit_event
+from llm_judge.control_plane.types import GuardrailDeniedError
+
+__all__ = [
+    "Guardrail",
+    "GuardrailContext",
+    "GuardrailDecision",
+    "_reset_for_tests",
+    "guardrail_context",
+    "register_guardrail",
+]
+
+
+class GuardrailDecision(BaseModel):
+    """Return type of guardrail ``pre_call`` and ``post_call`` hooks.
+
+    Allow/Deny only — Modify-on-return semantics are reserved for a
+    future packet (per L1-Pkt-B Decision 3c). When ``allowed`` is
+    False, ``reason`` is required and the substrate raises
+    :class:`GuardrailDeniedError` with the structured context
+    attached for downstream observers.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    allowed: bool
+    reason: str | None = None
+    context: dict[str, Any] = Field(default_factory=dict)
+
+    @classmethod
+    def allow(cls) -> GuardrailDecision:
+        """Construct an Allow decision."""
+        return cls(allowed=True)
+
+    @classmethod
+    def deny(cls, reason: str, **context: Any) -> GuardrailDecision:
+        """Construct a Deny decision. ``reason`` is required;
+        keyword arguments populate ``context`` for telemetry and the
+        :class:`GuardrailDeniedError` message."""
+        return cls(allowed=False, reason=reason, context=dict(context))
+
+
+class GuardrailContext(BaseModel):
+    """Per-invocation state passed to every guardrail hook.
+
+    Mutable: guardrails write to ``guardrail_state`` to carry handles
+    between ``pre_call`` and ``post_call`` (the timeout guardrail
+    stores a start timestamp, for example). Per-request scope only —
+    the dict does not persist across capability invocations or
+    across runs (Decision 3b, L1-Pkt-B; per-process / per-tenant
+    state deferred to a future packet).
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    spec: CapabilitySpec
+    request_id: str
+    guardrail_state: dict[str, Any] = Field(default_factory=dict)
+
+
+class Guardrail:
+    """Base class for guardrails.
+
+    Subclasses override ``pre_call``, ``post_call``, or both. Both
+    methods default to Allow so a subclass that only governs the
+    pre- or post- side of the call is not forced to write a no-op
+    on the other side.
+
+    Implementations should keep hook bodies fast and side-effect-
+    bounded; the substrate executes hooks synchronously around every
+    capability invocation and any cost is added to the per-request
+    latency budget.
+    """
+
+    def pre_call(self, ctx: GuardrailContext) -> GuardrailDecision:
+        """Run before the capability is invoked. Return Allow to
+        permit invocation; return Deny to short-circuit the call."""
+        del ctx
+        return GuardrailDecision.allow()
+
+    def post_call(self, ctx: GuardrailContext) -> GuardrailDecision:
+        """Run after the capability has executed (or attempted to
+        execute and raised — the substrate uses ``finally`` semantics
+        so post_call still fires on capability error). Return Allow
+        for a clean exit; return Deny to mark the invocation as
+        denied after-the-fact (used by the timeout guardrail's
+        Option β post-completion denial)."""
+        del ctx
+        return GuardrailDecision.allow()
+
+
+# Module-level registry of guardrails consumed by guardrail_context()
+# when no explicit override is passed. Populated by Commit 5 (timeout)
+# and future guardrail packets via register_guardrail.
+_REGISTERED_GUARDRAILS: list[Guardrail] = []
+
+
+def register_guardrail(guardrail: Guardrail) -> None:
+    """Add a guardrail to the global registry. All capability
+    invocations through :func:`guardrail_context` (without an
+    explicit ``guardrails`` override) will run this guardrail's
+    hooks."""
+    _REGISTERED_GUARDRAILS.append(guardrail)
+
+
+def _reset_for_tests() -> None:
+    """Clear the module-level guardrail registry. Tests that mutate
+    registered guardrails use this helper for isolation, matching
+    the :func:`llm_judge.control_plane.configuration._reset_for_tests`
+    pattern from L1-Pkt-1."""
+    _REGISTERED_GUARDRAILS.clear()
+
+
+def _raise_denied(
+    *,
+    guardrail_class: str,
+    spec: CapabilitySpec,
+    decision: GuardrailDecision,
+    phase: str,
+) -> None:
+    """Translate a Deny decision into a :class:`GuardrailDeniedError`
+    raise. Centralised so the message format and exception args
+    stay consistent across pre- and post- phases."""
+    reason = decision.reason or "(no reason supplied)"
+    raise GuardrailDeniedError(
+        f"Guardrail {guardrail_class} denied {spec.capability_id} "
+        f"({phase}): {reason}"
+    )
+
+
+@contextmanager
+def guardrail_context(
+    spec: CapabilitySpec,
+    request_id: str,
+    *,
+    guardrails: Sequence[Guardrail] | None = None,
+) -> Iterator[GuardrailContext]:
+    """Wrap a capability invocation with the guardrail substrate.
+
+    Pre-call hooks run before the with-block executes; if any
+    returns Deny, :class:`GuardrailDeniedError` is raised and the
+    capability is not invoked. Post-call hooks run after the
+    with-block exits (using ``finally``-like semantics so they run
+    even if the capability raised); a Deny here also raises
+    :class:`GuardrailDeniedError`.
+
+    Telemetry: each hook invocation emits a structlog/event-bus
+    event (``guardrail.pre_call`` or ``guardrail.post_call``) with
+    capability_id, request_id, guardrail class, allowed flag, and
+    reason. Concrete guardrails may emit additional events (e.g.
+    the timeout guardrail emits ``guardrail.timeout_exceeded``
+    when its post_call denies).
+
+    ``guardrails`` defaults to the module-level registry populated
+    by :func:`register_guardrail`; tests pass an explicit list to
+    isolate from registry state.
+    """
+    active = list(guardrails) if guardrails is not None else list(_REGISTERED_GUARDRAILS)
+    ctx = GuardrailContext(spec=spec, request_id=request_id)
+
+    for guard in active:
+        decision = guard.pre_call(ctx)
+        emit_event(
+            "guardrail.pre_call",
+            capability_id=spec.capability_id,
+            request_id=request_id,
+            guardrail=type(guard).__name__,
+            allowed=decision.allowed,
+            reason=decision.reason,
+        )
+        if not decision.allowed:
+            _raise_denied(
+                guardrail_class=type(guard).__name__,
+                spec=spec,
+                decision=decision,
+                phase="pre_call",
+            )
+
+    post_call_error: BaseException | None = None
+    try:
+        yield ctx
+    finally:
+        for guard in active:
+            try:
+                decision = guard.post_call(ctx)
+            except Exception as exc:
+                # Hook itself raised — record so we can re-raise once
+                # all hooks have had a chance to observe.
+                emit_event(
+                    "guardrail.post_call",
+                    capability_id=spec.capability_id,
+                    request_id=request_id,
+                    guardrail=type(guard).__name__,
+                    allowed=False,
+                    reason=f"hook raised: {type(exc).__name__}",
+                )
+                if post_call_error is None:
+                    post_call_error = exc
+                continue
+            emit_event(
+                "guardrail.post_call",
+                capability_id=spec.capability_id,
+                request_id=request_id,
+                guardrail=type(guard).__name__,
+                allowed=decision.allowed,
+                reason=decision.reason,
+            )
+            if not decision.allowed and post_call_error is None:
+                # Capture the raise; let any remaining hooks observe
+                # the invocation before propagating.
+                try:
+                    _raise_denied(
+                        guardrail_class=type(guard).__name__,
+                        spec=spec,
+                        decision=decision,
+                        phase="post_call",
+                    )
+                except GuardrailDeniedError as exc:
+                    post_call_error = exc
+        if post_call_error is not None:
+            raise post_call_error

--- a/src/llm_judge/control_plane/guardrails/timeout.py
+++ b/src/llm_judge/control_plane/guardrails/timeout.py
@@ -1,0 +1,94 @@
+"""TimeoutGuardrail — first concrete guardrail (CP-F12 closure, L1-Pkt-B Commit 5).
+
+Per-capability timeout enforcement on the substrate from Commit 3,
+wired around every invocation by Commit 4. Implementation strategy
+is **Option β (post-completion denial)** per Layer 1 chat checkpoint
+of L1-Pkt-B.
+
+Why post-completion denial:
+  Pre-flight 4 of L1-Pkt-B established that the entire Layer 1 stack
+  is synchronous — no asyncio anywhere, no threading, batch_runner
+  iterates cases in the main thread. The two viable sync timeout
+  strategies were:
+
+  * Option α — :func:`signal.alarm`: Unix-only, main-thread only,
+    nesting is fragile, library code can swallow signals. Brittle.
+  * Option β — post-call elapsed-time check: capability runs to
+    completion; pre_call records a start timestamp; post_call
+    computes elapsed and denies if the configured budget was
+    exceeded. Portable, no platform coupling.
+
+  The Layer 1 chat picked Option β. Trade-off recorded in the
+  L1-Pkt-B completion signal: this closes CP-F12 in the
+  observability sense (timeout breach is a materialised
+  :class:`GuardrailDeniedError` with structured context plus a
+  ``guardrail.timeout_exceeded`` telemetry event) but does NOT
+  bound resource consumption — a runaway capability continues to
+  hold the worker until it finishes naturally; only its outcome is
+  rejected.
+
+The unmet "actually interrupt a runaway capability" surface is
+filed as **CP-F23 candidate** for v1.5 gap analysis. Future packets
+may add bounded execution via subprocess sandboxing, async
+migration, or signal-based fallback for narrow cases.
+
+Pre_call sets ``ctx.guardrail_state[_TIMEOUT_START_KEY]`` to the
+current ``time.perf_counter()`` reading and returns Allow.
+Post_call reads that key, computes ``elapsed = perf_counter() -
+start``, compares against ``ctx.spec.timeout_seconds``, emits
+``guardrail.timeout_exceeded`` on breach, and returns Deny — the
+substrate translates that into a :class:`GuardrailDeniedError`
+that surfaces through the runner's per-arm exception handler
+(captured to integrity for CAP-1/CAP-2/CAP-7; propagated for
+CAP-5 per the D5 contract).
+"""
+
+from __future__ import annotations
+
+import time
+
+from llm_judge.control_plane.guardrails.substrate import (
+    Guardrail,
+    GuardrailContext,
+    GuardrailDecision,
+)
+from llm_judge.control_plane.observability import emit_event
+
+__all__ = ["TimeoutGuardrail"]
+
+
+_TIMEOUT_START_KEY = "timeout_guardrail.start_perf_counter"
+
+
+class TimeoutGuardrail(Guardrail):
+    """Per-request timeout enforcement (CP-F12 closure, Option β)."""
+
+    def pre_call(self, ctx: GuardrailContext) -> GuardrailDecision:
+        ctx.guardrail_state[_TIMEOUT_START_KEY] = time.perf_counter()
+        return GuardrailDecision.allow()
+
+    def post_call(self, ctx: GuardrailContext) -> GuardrailDecision:
+        start = ctx.guardrail_state.get(_TIMEOUT_START_KEY)
+        if start is None:
+            # pre_call did not run for this invocation; nothing to
+            # measure against. Substrate guarantees pre_call before
+            # post_call when the same guardrail instance is used,
+            # so this branch is defensive against future misuse.
+            return GuardrailDecision.allow()
+        elapsed = time.perf_counter() - start
+        configured = ctx.spec.timeout_seconds
+        if elapsed <= configured:
+            return GuardrailDecision.allow()
+        emit_event(
+            "guardrail.timeout_exceeded",
+            capability_id=ctx.spec.capability_id,
+            request_id=ctx.request_id,
+            configured_timeout_seconds=configured,
+            observed_duration_seconds=elapsed,
+        )
+        return GuardrailDecision.deny(
+            "timeout exceeded (post-completion denial)",
+            capability_id=ctx.spec.capability_id,
+            configured_timeout_seconds=configured,
+            observed_duration_seconds=elapsed,
+        )

--- a/src/llm_judge/control_plane/runner.py
+++ b/src/llm_judge/control_plane/runner.py
@@ -7,6 +7,17 @@ Error-handling contract (CP-1b D5):
   (CAP-1, CAP-2, CAP-7) and records the outcome in the envelope's
   per-capability integrity list. CAP-5 is NOT wrapped — its failures
   still propagate.
+
+Registry-driven iteration (CP-F9 closure, L1-Pkt-B):
+  :data:`CAPABILITY_REGISTRY` defines the capability sequence and
+  per-capability operational metadata. ``run_single_evaluation``
+  iterates the registry and dispatches by ``capability_id`` to the
+  matching arm (Option A from L1-Pkt-B Layer 1 chat checkpoint).
+  Per-arm logic is preserved verbatim — heterogeneous signatures
+  and conditional dispatch on CAP-1 failure / aggregation between
+  CAP-7 and CAP-5 make a uniform-signature refactor out of scope.
+  Adding a fifth capability requires both a registry entry and a
+  new dispatch arm here.
 """
 
 from __future__ import annotations
@@ -20,6 +31,7 @@ from typing import Any
 
 import structlog
 
+from llm_judge.control_plane.capability_registry import CAPABILITY_REGISTRY
 from llm_judge.control_plane.configuration import validate_configuration
 from llm_judge.control_plane.envelope import (
     CapabilityIntegrityRecord,
@@ -214,208 +226,246 @@ class PlatformRunner:
             platform_version=self._platform_version,
         )
 
+        # State accumulated across registry iterations. Declared above
+        # the loop so dispatch arms can read prior-arm output (e.g.
+        # CAP-2/CAP-7 read ``dataset_handle`` from CAP-1; CAP-5's
+        # aggregation reads ``rule_hits``/``verdict_from_cap7``).
+        # ``integrity`` and ``manifest_id`` are populated by CAP-5's
+        # arm; the placeholders satisfy the type checker on the
+        # never-reached path where CAP-5 is absent from the registry
+        # (registry is strict-from-day-one — CAP-5 is always last).
+        dataset_handle: Any = None
+        cap1_failed = False
+        missing: list[str] = []
+        reasons: list[str] = []
+        rule_hits: list[str] = []
+        cap2_succeeded = False
+        verdict_from_cap7: dict[str, Any] = {}
+        cap7_succeeded = False
+        aggregated: dict[str, Any] = {}
+        integrity = Integrity(complete=False)
+        manifest_id = ""
+
         with run_timer:
-            # --- CAP-1 (wrapped; failure is captured, not propagated) ---
-            dataset_handle: Any = None
-            cap1_failed = False
-            emit_event(
-                "capability_started",
-                capability_id="CAP-1",
-                request_id=request_id,
-                timestamp=_utc_now_iso(),
-            )
-            cap1_timer = Timer()
-            try:
-                with cap1_timer:
-                    envelope, dataset_handle = invoke_cap1(
-                        envelope, payload, transient_root=self._transient_root
-                    )
-                envelope = envelope.with_integrity(
-                    _success_record("CAP-1", duration_ms=cap1_timer.duration_ms)
-                )
-                emit_event(
-                    "capability_completed",
-                    capability_id="CAP-1",
-                    request_id=request_id,
-                    duration_ms=cap1_timer.duration_ms,
-                    status="success",
-                )
-            except Exception as exc:
-                cap1_failed = True
-                envelope = envelope.with_integrity(
-                    _failure_record("CAP-1", exc, duration_ms=cap1_timer.duration_ms)
-                )
-                envelope = envelope.with_integrity(_skipped_record("CAP-2"))
-                envelope = envelope.with_integrity(_skipped_record("CAP-7"))
-                emit_event(
-                    "capability_failed",
-                    capability_id="CAP-1",
-                    request_id=request_id,
-                    duration_ms=cap1_timer.duration_ms,
-                    status="failure",
-                    error_type=type(exc).__name__,
-                    error_message=str(exc)[:500],
-                )
-                logger.warning(
-                    "control_plane.cap1_failed",
-                    request_id=request_id,
-                    error=str(exc)[:200],
-                )
+            for spec in CAPABILITY_REGISTRY:
+                cap_id = spec.capability_id
 
-            # --- Sibling phase: CAP-2 and CAP-7 (failures tolerated) ---
-            missing: list[str] = []
-            reasons: list[str] = []
-            rule_hits: list[str] = []
-            cap2_succeeded = False
-            verdict_from_cap7: dict[str, Any] = {}
-            cap7_succeeded = False
-
-            if cap1_failed:
-                missing.extend(["CAP-2", "CAP-7"])
-                reasons.append("CAP-1 failed; siblings skipped")
-            else:
-                emit_event(
-                    "capability_started",
-                    capability_id="CAP-2",
-                    request_id=request_id,
-                    timestamp=_utc_now_iso(),
-                )
-                cap2_timer = Timer()
-                try:
-                    with cap2_timer:
-                        envelope, rule_hits = invoke_cap2(
-                            envelope, payload, dataset_handle
-                        )
-                    envelope = envelope.with_integrity(
-                        _success_record("CAP-2", duration_ms=cap2_timer.duration_ms)
-                    )
-                    cap2_succeeded = True
+                if cap_id == "CAP-1":
+                    # CAP-1 (wrapped; failure is captured, not propagated)
                     emit_event(
-                        "capability_completed",
+                        "capability_started",
+                        capability_id="CAP-1",
+                        request_id=request_id,
+                        timestamp=_utc_now_iso(),
+                    )
+                    cap1_timer = Timer()
+                    try:
+                        with cap1_timer:
+                            envelope, dataset_handle = invoke_cap1(
+                                envelope, payload, transient_root=self._transient_root
+                            )
+                        envelope = envelope.with_integrity(
+                            _success_record("CAP-1", duration_ms=cap1_timer.duration_ms)
+                        )
+                        emit_event(
+                            "capability_completed",
+                            capability_id="CAP-1",
+                            request_id=request_id,
+                            duration_ms=cap1_timer.duration_ms,
+                            status="success",
+                        )
+                    except Exception as exc:
+                        cap1_failed = True
+                        envelope = envelope.with_integrity(
+                            _failure_record(
+                                "CAP-1", exc, duration_ms=cap1_timer.duration_ms
+                            )
+                        )
+                        # Sibling-skip reason recorded once at the
+                        # CAP-1 failure boundary; CAP-2 and CAP-7 arms
+                        # only stamp their own skipped records.
+                        reasons.append("CAP-1 failed; siblings skipped")
+                        emit_event(
+                            "capability_failed",
+                            capability_id="CAP-1",
+                            request_id=request_id,
+                            duration_ms=cap1_timer.duration_ms,
+                            status="failure",
+                            error_type=type(exc).__name__,
+                            error_message=str(exc)[:500],
+                        )
+                        logger.warning(
+                            "control_plane.cap1_failed",
+                            request_id=request_id,
+                            error=str(exc)[:200],
+                        )
+
+                elif cap_id == "CAP-2":
+                    # CAP-2 (wrapped; failure is captured, not propagated)
+                    if cap1_failed:
+                        envelope = envelope.with_integrity(_skipped_record("CAP-2"))
+                        missing.append("CAP-2")
+                        continue
+                    emit_event(
+                        "capability_started",
                         capability_id="CAP-2",
                         request_id=request_id,
-                        duration_ms=cap2_timer.duration_ms,
-                        status="success",
+                        timestamp=_utc_now_iso(),
                     )
-                except Exception as exc:
-                    missing.append("CAP-2")
-                    reasons.append(f"CAP-2: {type(exc).__name__}: {exc}")
-                    envelope = envelope.with_integrity(
-                        _failure_record("CAP-2", exc, duration_ms=cap2_timer.duration_ms)
-                    )
-                    emit_event(
-                        "capability_failed",
-                        capability_id="CAP-2",
-                        request_id=request_id,
-                        duration_ms=cap2_timer.duration_ms,
-                        status="failure",
-                        error_type=type(exc).__name__,
-                        error_message=str(exc)[:500],
-                    )
-                    logger.warning(
-                        "control_plane.cap2_failed",
-                        request_id=request_id,
-                        error=str(exc)[:200],
-                    )
-
-                emit_event(
-                    "capability_started",
-                    capability_id="CAP-7",
-                    request_id=request_id,
-                    timestamp=_utc_now_iso(),
-                )
-                cap7_timer = Timer()
-                try:
-                    with cap7_timer:
-                        envelope, verdict_from_cap7 = invoke_cap7(
-                            envelope, payload, dataset_handle, layers=active_layers
+                    cap2_timer = Timer()
+                    try:
+                        with cap2_timer:
+                            envelope, rule_hits = invoke_cap2(
+                                envelope, payload, dataset_handle
+                            )
+                        envelope = envelope.with_integrity(
+                            _success_record("CAP-2", duration_ms=cap2_timer.duration_ms)
                         )
-                    envelope = envelope.with_integrity(
-                        _success_record("CAP-7", duration_ms=cap7_timer.duration_ms)
-                    )
-                    cap7_succeeded = True
+                        cap2_succeeded = True
+                        emit_event(
+                            "capability_completed",
+                            capability_id="CAP-2",
+                            request_id=request_id,
+                            duration_ms=cap2_timer.duration_ms,
+                            status="success",
+                        )
+                    except Exception as exc:
+                        missing.append("CAP-2")
+                        reasons.append(f"CAP-2: {type(exc).__name__}: {exc}")
+                        envelope = envelope.with_integrity(
+                            _failure_record(
+                                "CAP-2", exc, duration_ms=cap2_timer.duration_ms
+                            )
+                        )
+                        emit_event(
+                            "capability_failed",
+                            capability_id="CAP-2",
+                            request_id=request_id,
+                            duration_ms=cap2_timer.duration_ms,
+                            status="failure",
+                            error_type=type(exc).__name__,
+                            error_message=str(exc)[:500],
+                        )
+                        logger.warning(
+                            "control_plane.cap2_failed",
+                            request_id=request_id,
+                            error=str(exc)[:200],
+                        )
+
+                elif cap_id == "CAP-7":
+                    # CAP-7 (wrapped; failure is captured, not propagated)
+                    if cap1_failed:
+                        envelope = envelope.with_integrity(_skipped_record("CAP-7"))
+                        missing.append("CAP-7")
+                        continue
                     emit_event(
-                        "capability_completed",
+                        "capability_started",
                         capability_id="CAP-7",
                         request_id=request_id,
-                        duration_ms=cap7_timer.duration_ms,
-                        status="success",
+                        timestamp=_utc_now_iso(),
                     )
-                except Exception as exc:
-                    missing.append("CAP-7")
-                    reasons.append(f"CAP-7: {type(exc).__name__}: {exc}")
-                    envelope = envelope.with_integrity(
-                        _failure_record("CAP-7", exc, duration_ms=cap7_timer.duration_ms)
+                    cap7_timer = Timer()
+                    try:
+                        with cap7_timer:
+                            envelope, verdict_from_cap7 = invoke_cap7(
+                                envelope, payload, dataset_handle, layers=active_layers
+                            )
+                        envelope = envelope.with_integrity(
+                            _success_record("CAP-7", duration_ms=cap7_timer.duration_ms)
+                        )
+                        cap7_succeeded = True
+                        emit_event(
+                            "capability_completed",
+                            capability_id="CAP-7",
+                            request_id=request_id,
+                            duration_ms=cap7_timer.duration_ms,
+                            status="success",
+                        )
+                    except Exception as exc:
+                        missing.append("CAP-7")
+                        reasons.append(f"CAP-7: {type(exc).__name__}: {exc}")
+                        envelope = envelope.with_integrity(
+                            _failure_record(
+                                "CAP-7", exc, duration_ms=cap7_timer.duration_ms
+                            )
+                        )
+                        emit_event(
+                            "capability_failed",
+                            capability_id="CAP-7",
+                            request_id=request_id,
+                            duration_ms=cap7_timer.duration_ms,
+                            status="failure",
+                            error_type=type(exc).__name__,
+                            error_message=str(exc)[:500],
+                        )
+                        logger.warning(
+                            "control_plane.cap7_failed",
+                            request_id=request_id,
+                            error=str(exc)[:200],
+                        )
+
+                elif cap_id == "CAP-5":
+                    # Aggregate CAP-7 verdict (if any) + CAP-2 rule_hits,
+                    # then build the run-level Integrity summary that CAP-5
+                    # consumes as input.
+                    if cap7_succeeded:
+                        aggregated.update(verdict_from_cap7)
+                    if cap2_succeeded:
+                        aggregated["rule_evidence"] = list(rule_hits)
+                    integrity = Integrity(
+                        complete=not missing and not cap1_failed,
+                        missing_capabilities=(
+                            ["CAP-1", "CAP-2", "CAP-7"] if cap1_failed else missing
+                        ),
+                        reason="; ".join(reasons) if reasons else None,
                     )
+
+                    # CAP-5 (propagates; not wrapped per D5)
                     emit_event(
-                        "capability_failed",
-                        capability_id="CAP-7",
+                        "capability_started",
+                        capability_id="CAP-5",
                         request_id=request_id,
-                        duration_ms=cap7_timer.duration_ms,
-                        status="failure",
-                        error_type=type(exc).__name__,
-                        error_message=str(exc)[:500],
+                        timestamp=_utc_now_iso(),
                     )
-                    logger.warning(
-                        "control_plane.cap7_failed",
-                        request_id=request_id,
-                        error=str(exc)[:200],
+                    cap5_timer = Timer()
+                    try:
+                        with cap5_timer:
+                            envelope, manifest_id = invoke_cap5(
+                                envelope,
+                                aggregated,
+                                integrity.model_dump(),
+                                rubric_id=payload.rubric_id,
+                                rubric_version=payload.rubric_version,
+                                runs_root=runs_root,
+                            )
+                        envelope = envelope.with_integrity(
+                            _success_record("CAP-5", duration_ms=cap5_timer.duration_ms)
+                        )
+                        emit_event(
+                            "capability_completed",
+                            capability_id="CAP-5",
+                            request_id=request_id,
+                            duration_ms=cap5_timer.duration_ms,
+                            status="success",
+                        )
+                    except Exception as exc:
+                        emit_event(
+                            "capability_failed",
+                            capability_id="CAP-5",
+                            request_id=request_id,
+                            duration_ms=cap5_timer.duration_ms,
+                            status="failure",
+                            error_type=type(exc).__name__,
+                            error_message=str(exc)[:500],
+                        )
+                        raise
+
+                else:
+                    raise RuntimeError(
+                        f"PlatformRunner has no dispatch arm for "
+                        f"capability_id={cap_id!r}; CAPABILITY_REGISTRY "
+                        f"and runner.py disagree."
                     )
-
-            # --- Aggregate: CAP-7 verdict (if any) + CAP-2 rule_hits ---
-            aggregated: dict[str, Any] = {}
-            if cap7_succeeded:
-                aggregated.update(verdict_from_cap7)
-            if cap2_succeeded:
-                aggregated["rule_evidence"] = list(rule_hits)
-
-            integrity = Integrity(
-                complete=not missing and not cap1_failed,
-                missing_capabilities=(
-                    ["CAP-1", "CAP-2", "CAP-7"] if cap1_failed else missing
-                ),
-                reason="; ".join(reasons) if reasons else None,
-            )
-
-            # --- CAP-5 (propagates; not wrapped per D5) ---
-            emit_event(
-                "capability_started",
-                capability_id="CAP-5",
-                request_id=request_id,
-                timestamp=_utc_now_iso(),
-            )
-            cap5_timer = Timer()
-            try:
-                with cap5_timer:
-                    envelope, manifest_id = invoke_cap5(
-                        envelope,
-                        aggregated,
-                        integrity.model_dump(),
-                        rubric_id=payload.rubric_id,
-                        rubric_version=payload.rubric_version,
-                        runs_root=runs_root,
-                    )
-                envelope = envelope.with_integrity(
-                    _success_record("CAP-5", duration_ms=cap5_timer.duration_ms)
-                )
-                emit_event(
-                    "capability_completed",
-                    capability_id="CAP-5",
-                    request_id=request_id,
-                    duration_ms=cap5_timer.duration_ms,
-                    status="success",
-                )
-            except Exception as exc:
-                emit_event(
-                    "capability_failed",
-                    capability_id="CAP-5",
-                    request_id=request_id,
-                    duration_ms=cap5_timer.duration_ms,
-                    status="failure",
-                    error_type=type(exc).__name__,
-                    error_message=str(exc)[:500],
-                )
-                raise
 
         emit_event(
             "run_completed",

--- a/src/llm_judge/control_plane/runner.py
+++ b/src/llm_judge/control_plane/runner.py
@@ -18,6 +18,18 @@ Registry-driven iteration (CP-F9 closure, L1-Pkt-B):
   CAP-7 and CAP-5 make a uniform-signature refactor out of scope.
   Adding a fifth capability requires both a registry entry and a
   new dispatch arm here.
+
+Guardrail substrate (CP-F8 closure, L1-Pkt-B):
+  Each ``invoke_capN`` call inside this Runner executes within a
+  :func:`guardrail_context`. The substrate iterates registered
+  guardrails: pre-call hooks fire before the capability runs;
+  post-call hooks fire after. A guardrail's Deny decision raises
+  :class:`GuardrailDeniedError`, which the per-arm ``except
+  Exception`` handlers (CAP-1/CAP-2/CAP-7) record as a capability
+  failure or which (CAP-5) propagates per the D5 contract. Concrete
+  guardrails register via
+  :func:`llm_judge.control_plane.guardrails.register_guardrail`;
+  L1-Pkt-B Commit 5 registers TimeoutGuardrail as the first.
 """
 
 from __future__ import annotations
@@ -37,6 +49,7 @@ from llm_judge.control_plane.envelope import (
     CapabilityIntegrityRecord,
     new_envelope,
 )
+from llm_judge.control_plane.guardrails import guardrail_context
 from llm_judge.control_plane.observability import Timer, emit_event
 from llm_judge.control_plane.types import (
     Integrity,
@@ -260,7 +273,7 @@ class PlatformRunner:
                     )
                     cap1_timer = Timer()
                     try:
-                        with cap1_timer:
+                        with guardrail_context(spec, request_id), cap1_timer:
                             envelope, dataset_handle = invoke_cap1(
                                 envelope, payload, transient_root=self._transient_root
                             )
@@ -314,7 +327,7 @@ class PlatformRunner:
                     )
                     cap2_timer = Timer()
                     try:
-                        with cap2_timer:
+                        with guardrail_context(spec, request_id), cap2_timer:
                             envelope, rule_hits = invoke_cap2(
                                 envelope, payload, dataset_handle
                             )
@@ -366,7 +379,7 @@ class PlatformRunner:
                     )
                     cap7_timer = Timer()
                     try:
-                        with cap7_timer:
+                        with guardrail_context(spec, request_id), cap7_timer:
                             envelope, verdict_from_cap7 = invoke_cap7(
                                 envelope, payload, dataset_handle, layers=active_layers
                             )
@@ -429,7 +442,7 @@ class PlatformRunner:
                     )
                     cap5_timer = Timer()
                     try:
-                        with cap5_timer:
+                        with guardrail_context(spec, request_id), cap5_timer:
                             envelope, manifest_id = invoke_cap5(
                                 envelope,
                                 aggregated,

--- a/src/llm_judge/control_plane/types.py
+++ b/src/llm_judge/control_plane/types.py
@@ -19,6 +19,7 @@ __all__ = [
     "CapabilityIntegrityRecord",
     "ConfigurationError",
     "FieldOwnershipViolationError",
+    "GuardrailDeniedError",
     "Integrity",
     "MissingProvenanceError",
     "RubricNotInRegistryError",
@@ -39,6 +40,30 @@ class ConfigurationError(Exception):
     an HMAC key is the first instance; subsequent packets extend
     ``validate_configuration()`` to cover layer vocabulary alignment,
     artifact root validation, and governance preflight reachability."""
+
+
+class GuardrailDeniedError(ConfigurationError):
+    """Raised by the guardrail substrate when a registered guardrail's
+    pre_call or post_call hook returns a Deny decision (CP-F8 substrate
+    + CP-F12 timeout closure, L1-Pkt-B).
+
+    Subclasses :class:`ConfigurationError` so existing
+    ``except ConfigurationError:`` handlers continue to catch denial
+    events — the runner's per-capability ``except Exception`` arms
+    pick up these denials as capability failures alongside other
+    operational errors (for CAP-1/CAP-2/CAP-7) or propagate them
+    (for CAP-5, per the D5 contract). New callers can ``except
+    GuardrailDeniedError:`` specifically to distinguish guardrail-
+    initiated denials from other configuration errors.
+
+    The message names the offending guardrail, capability_id, and
+    decision reason so the failure is self-describing in logs and
+    integrity records.
+
+    Reserved namespace: future guardrails (rate limit, circuit
+    breaker, kill switch) raise more specific subclasses of this
+    class so handlers can discriminate by guardrail family without
+    parsing message strings."""
 
 
 class BenchmarkFileNotFoundError(ValueError):

--- a/tests/control_plane/test_capability_registry.py
+++ b/tests/control_plane/test_capability_registry.py
@@ -1,0 +1,95 @@
+"""Capability-registry shape and lookup tests (CP-F9 mechanism).
+
+Verifies the runtime catalogue produced in Commit 1 of L1-Pkt-B.
+Orchestrator iteration (Commit 2) and substrate wiring (Commits 3-5)
+are covered separately.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from llm_judge.control_plane.capability_registry import (
+    CAPABILITY_REGISTRY,
+    CapabilitySpec,
+    get_spec,
+)
+
+# ---------------------------------------------------------------------
+# Shape
+# ---------------------------------------------------------------------
+
+
+def test_registry_is_a_tuple_of_capability_specs() -> None:
+    assert isinstance(CAPABILITY_REGISTRY, tuple)
+    assert all(isinstance(spec, CapabilitySpec) for spec in CAPABILITY_REGISTRY)
+
+
+def test_registry_lists_recon_confirmed_capabilities() -> None:
+    """The four capabilities currently orchestrated all appear; new
+    capabilities require an explicit registry update + dispatch arm."""
+    ids = [spec.capability_id for spec in CAPABILITY_REGISTRY]
+    assert ids == ["CAP-1", "CAP-2", "CAP-7", "CAP-5"]
+
+
+def test_sequence_position_matches_tuple_index() -> None:
+    """``sequence_position`` is redundant-but-explicit; assert the
+    self-describing invariant holds at module load."""
+    for index, spec in enumerate(CAPABILITY_REGISTRY):
+        assert spec.sequence_position == index
+
+
+# ---------------------------------------------------------------------
+# Initial timeout values (Pre-flight 3 latency catalog)
+# ---------------------------------------------------------------------
+
+
+def test_cap1_cap2_cap5_timeouts_are_five_seconds() -> None:
+    """CAP-1, CAP-2, CAP-5 P99 latency is sub-50 ms in test runs;
+    a 5 s timeout is >100x P99 and absorbs CI-environment jitter."""
+    assert get_spec("CAP-1").timeout_seconds == 5.0
+    assert get_spec("CAP-2").timeout_seconds == 5.0
+    assert get_spec("CAP-5").timeout_seconds == 5.0
+
+
+def test_cap7_timeout_is_thirty_seconds() -> None:
+    """CAP-7 P99 ≈ 3925 ms in test runs (case-0 LLM warm-up); 30 s
+    gives extra headroom over the strict 5x rule for warm-up
+    volatility. Tune post-deployment from production traffic."""
+    assert get_spec("CAP-7").timeout_seconds == 30.0
+
+
+def test_all_timeouts_are_positive() -> None:
+    """Pydantic ``Field(..., gt=0)`` enforces this at construction;
+    re-asserting documents the invariant for readers and catches a
+    future spec that drifts past validator weakening."""
+    for spec in CAPABILITY_REGISTRY:
+        assert spec.timeout_seconds > 0
+
+
+# ---------------------------------------------------------------------
+# Frozen Pydantic — instances are values, not handles
+# ---------------------------------------------------------------------
+
+
+def test_capability_spec_is_frozen() -> None:
+    spec = CAPABILITY_REGISTRY[0]
+    with pytest.raises(Exception):
+        spec.timeout_seconds = 99.0
+
+
+# ---------------------------------------------------------------------
+# Lookup
+# ---------------------------------------------------------------------
+
+
+def test_get_spec_returns_matching_entry() -> None:
+    spec = get_spec("CAP-7")
+    assert spec.capability_id == "CAP-7"
+    assert spec.sequence_position == 2
+    assert spec.timeout_seconds == 30.0
+
+
+def test_get_spec_raises_key_error_for_unknown_id() -> None:
+    with pytest.raises(KeyError, match="CAP-99"):
+        get_spec("CAP-99")

--- a/tests/control_plane/test_capability_registry.py
+++ b/tests/control_plane/test_capability_registry.py
@@ -93,3 +93,37 @@ def test_get_spec_returns_matching_entry() -> None:
 def test_get_spec_raises_key_error_for_unknown_id() -> None:
     with pytest.raises(KeyError, match="CAP-99"):
         get_spec("CAP-99")
+
+
+# ---------------------------------------------------------------------
+# Iteration order drives orchestrator (CP-F9 closure check)
+# ---------------------------------------------------------------------
+
+
+def test_runner_invocation_order_matches_registry(tmp_path: object) -> None:
+    """End-to-end: the per-capability integrity records on the envelope
+    after a successful run appear in the same order as the registry,
+    proving the registry drives the orchestrator's iteration. Reordering
+    the registry's tuple would flip this assertion."""
+    from pathlib import Path
+
+    from llm_judge.control_plane.runner import PlatformRunner
+    from llm_judge.control_plane.types import SingleEvaluationRequest
+
+    assert isinstance(tmp_path, Path)
+    runner = PlatformRunner(
+        platform_version="registry-iter-sha",
+        transient_root=tmp_path / "transient",
+        runs_root=tmp_path / "runs",
+    )
+    result = runner.run_single_evaluation(
+        SingleEvaluationRequest(
+            response="Paris is the capital of France.",
+            source="Paris is the capital of France and its largest city.",
+            rubric_id="chat_quality",
+            caller_id="registry-iter-test",
+        )
+    )
+    invoked = [rec.capability_id for rec in result.envelope.integrity]
+    expected = [spec.capability_id for spec in CAPABILITY_REGISTRY]
+    assert invoked == expected

--- a/tests/control_plane/test_capability_registry_gap_absence.py
+++ b/tests/control_plane/test_capability_registry_gap_absence.py
@@ -1,0 +1,165 @@
+"""CP-F9 gap-absence test (AST-walking).
+
+Per Brief Template v1.3: a gap-absence test exercises the closure
+surface and would fail if the runtime gate introduced by L1-Pkt-B
+Commit 2 were reverted.
+
+End-State property D2.1 + D2.2 transition the capability registry
+from convention to runtime gate. This test asserts:
+
+  * No production module under ``src/llm_judge/control_plane/``
+    (other than ``capability_registry.py`` itself) contains a
+    list/tuple literal with all four capability ids — that is, a
+    hard-coded sequence that bypasses the registry.
+
+  * Any function that calls three or more of the four
+    ``invoke_capN`` wrappers must iterate :data:`CAPABILITY_REGISTRY`
+    inside its body. Calling the wrappers in sequence without the
+    registry-driven loop is the exact pre-L1-Pkt-B shape; this
+    catches a regression there.
+
+If L1-Pkt-B Commit 2 were reverted (orchestrator goes back to the
+hard-coded CAP-1 → CAP-2 → CAP-7 → CAP-5 inline sequence), the
+``run_single_evaluation`` body would call all four ``invoke_capN``
+without a ``for ... in CAPABILITY_REGISTRY`` loop and the second
+assertion below would fire.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTROL_PLANE_ROOT = REPO_ROOT / "src" / "llm_judge" / "control_plane"
+
+# Modules excluded from the literal-sequence check because they are
+# the registry definitions themselves. ``capability_registry.py``
+# defines CAPABILITY_REGISTRY; tests for that file live elsewhere.
+LITERAL_CHECK_EXCLUDED_FILES: frozenset[str] = frozenset(
+    {"capability_registry.py"}
+)
+
+CAP_IDS: frozenset[str] = frozenset({"CAP-1", "CAP-2", "CAP-7", "CAP-5"})
+
+INVOKE_NAMES: frozenset[str] = frozenset(
+    {"invoke_cap1", "invoke_cap2", "invoke_cap5", "invoke_cap7"}
+)
+
+REGISTRY_NAME = "CAPABILITY_REGISTRY"
+
+
+def _iter_module_files() -> list[Path]:
+    return sorted(p for p in CONTROL_PLANE_ROOT.rglob("*.py") if p.is_file())
+
+
+def _string_literal(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _list_or_tuple_string_values(node: ast.AST) -> set[str] | None:
+    """Return the string-literal members of ``node`` if it is a list
+    or tuple literal whose elements are all string constants. Else
+    ``None``."""
+    if not isinstance(node, (ast.List, ast.Tuple)):
+        return None
+    members: set[str] = set()
+    for elt in node.elts:
+        s = _string_literal(elt)
+        if s is None:
+            return None
+        members.add(s)
+    return members
+
+
+def _function_invoke_call_names(
+    func: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> set[str]:
+    """Names of ``invoke_capN`` wrappers called inside ``func``."""
+    called: set[str] = set()
+    for child in ast.walk(func):
+        if isinstance(child, ast.Call):
+            f = child.func
+            name: str | None = None
+            if isinstance(f, ast.Name):
+                name = f.id
+            elif isinstance(f, ast.Attribute):
+                name = f.attr
+            if name is not None and name in INVOKE_NAMES:
+                called.add(name)
+    return called
+
+
+def _function_iterates_registry(
+    func: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> bool:
+    """True iff the function body contains ``for ... in CAPABILITY_REGISTRY``
+    (the registry-driven iteration the runner uses post-Commit 2)."""
+    for child in ast.walk(func):
+        if isinstance(child, ast.For) and isinstance(child.iter, ast.Name):
+            if child.iter.id == REGISTRY_NAME:
+                return True
+    return False
+
+
+# ---------------------------------------------------------------------
+# Heuristic 1 — no list/tuple literal with all four capability ids
+# outside the registry definition file.
+# ---------------------------------------------------------------------
+
+
+def test_no_hard_coded_capability_sequence_literal() -> None:
+    """A list/tuple containing all four capability id strings is a
+    hard-coded orchestration sequence that bypasses the registry.
+    Dict keys are not considered a sequence (registries are dicts/
+    tuples-of-models)."""
+    offenders: list[tuple[Path, int]] = []
+    for module_path in _iter_module_files():
+        if module_path.name in LITERAL_CHECK_EXCLUDED_FILES:
+            continue
+        tree = ast.parse(module_path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            members = _list_or_tuple_string_values(node)
+            if members is None:
+                continue
+            if CAP_IDS.issubset(members):
+                lineno = getattr(node, "lineno", -1)
+                offenders.append((module_path, lineno))
+    assert not offenders, (
+        "Found list/tuple literals containing all four capability ids "
+        "outside capability_registry.py — that is a hard-coded "
+        "capability sequence that bypasses CAPABILITY_REGISTRY. "
+        f"Offenders: {offenders}"
+    )
+
+
+# ---------------------------------------------------------------------
+# Heuristic 2 — any function calling 3+ invoke_capN wrappers must
+# iterate CAPABILITY_REGISTRY in its body.
+# ---------------------------------------------------------------------
+
+
+def test_multi_capability_callers_iterate_registry() -> None:
+    """Calling three or more ``invoke_capN`` wrappers without a
+    ``for ... in CAPABILITY_REGISTRY`` loop is exactly the shape of
+    the pre-L1-Pkt-B hard-coded orchestrator. Any reversion of
+    Commit 2 makes ``run_single_evaluation`` fail this assertion."""
+    offenders: list[tuple[Path, str, int, set[str]]] = []
+    for module_path in _iter_module_files():
+        tree = ast.parse(module_path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            called = _function_invoke_call_names(node)
+            if len(called) < 3:
+                continue
+            if _function_iterates_registry(node):
+                continue
+            offenders.append((module_path, node.name, node.lineno, called))
+    assert not offenders, (
+        "Functions calling 3+ invoke_capN wrappers must iterate "
+        "CAPABILITY_REGISTRY (the registry-driven orchestrator shape). "
+        f"Offenders: {offenders}"
+    )

--- a/tests/control_plane/test_guardrails_runner_integration.py
+++ b/tests/control_plane/test_guardrails_runner_integration.py
@@ -1,0 +1,77 @@
+"""Substrate-wired runner integration test (CP-F8 closure, L1-Pkt-B Commit 4).
+
+Verifies that ``PlatformRunner.run_single_evaluation`` actually
+invokes registered guardrails' pre_call and post_call hooks for
+every capability in :data:`CAPABILITY_REGISTRY`. The full mock-
+guardrail-Deny gap-absence test lives in Commit 7 (separate file);
+this file covers the wiring assertion.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from llm_judge.control_plane.capability_registry import CAPABILITY_REGISTRY
+from llm_judge.control_plane.guardrails import (
+    Guardrail,
+    GuardrailContext,
+    GuardrailDecision,
+    _reset_for_tests,
+    register_guardrail,
+)
+from llm_judge.control_plane.runner import PlatformRunner
+from llm_judge.control_plane.types import SingleEvaluationRequest
+
+
+@pytest.fixture(autouse=True)
+def reset_guardrail_registry() -> None:
+    _reset_for_tests()
+
+
+class _RecordingGuardrail(Guardrail):
+    """Records every pre_call and post_call invocation by capability_id."""
+
+    def __init__(self) -> None:
+        self.pre_calls: list[str] = []
+        self.post_calls: list[str] = []
+
+    def pre_call(self, ctx: GuardrailContext) -> GuardrailDecision:
+        self.pre_calls.append(ctx.spec.capability_id)
+        return GuardrailDecision.allow()
+
+    def post_call(self, ctx: GuardrailContext) -> GuardrailDecision:
+        self.post_calls.append(ctx.spec.capability_id)
+        return GuardrailDecision.allow()
+
+
+def _payload() -> SingleEvaluationRequest:
+    return SingleEvaluationRequest(
+        response="Paris is the capital of France.",
+        source="Paris is the capital of France and its largest city.",
+        rubric_id="chat_quality",
+        caller_id="substrate-wiring-test",
+    )
+
+
+def test_substrate_fires_pre_and_post_hooks_for_every_capability(
+    tmp_path: Path,
+) -> None:
+    """Registered guardrails see one pre_call and one post_call per
+    capability in registry order. If Commit 4's substrate wrap were
+    reverted, the recorder lists would be empty for some or all
+    capabilities."""
+    spy = _RecordingGuardrail()
+    register_guardrail(spy)
+
+    runner = PlatformRunner(
+        platform_version="substrate-wiring-sha",
+        transient_root=tmp_path / "transient",
+        runs_root=tmp_path / "runs",
+    )
+    runner.run_single_evaluation(_payload())
+
+    expected = [spec.capability_id for spec in CAPABILITY_REGISTRY]
+    assert spy.pre_calls == expected
+    assert spy.post_calls == expected

--- a/tests/control_plane/test_guardrails_runner_integration.py
+++ b/tests/control_plane/test_guardrails_runner_integration.py
@@ -9,6 +9,7 @@ this file covers the wiring assertion.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -18,16 +19,22 @@ from llm_judge.control_plane.guardrails import (
     Guardrail,
     GuardrailContext,
     GuardrailDecision,
-    _reset_for_tests,
     register_guardrail,
 )
+from llm_judge.control_plane.guardrails import substrate as _substrate
 from llm_judge.control_plane.runner import PlatformRunner
 from llm_judge.control_plane.types import SingleEvaluationRequest
 
 
 @pytest.fixture(autouse=True)
-def reset_guardrail_registry() -> None:
-    _reset_for_tests()
+def isolated_guardrail_registry() -> Iterator[None]:
+    saved = list(_substrate._REGISTERED_GUARDRAILS)
+    _substrate._REGISTERED_GUARDRAILS.clear()
+    try:
+        yield
+    finally:
+        _substrate._REGISTERED_GUARDRAILS.clear()
+        _substrate._REGISTERED_GUARDRAILS.extend(saved)
 
 
 class _RecordingGuardrail(Guardrail):

--- a/tests/control_plane/test_guardrails_substrate.py
+++ b/tests/control_plane/test_guardrails_substrate.py
@@ -1,0 +1,178 @@
+"""Guardrail substrate primitive tests (CP-F8 scaffold, L1-Pkt-B Commit 3).
+
+Pure scaffold coverage: decision shapes, context lifecycle, hook
+ordering, registry isolation. Orchestrator wiring is exercised by
+Commit 4's tests; concrete guardrails (timeout) by Commit 5.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from llm_judge.control_plane.capability_registry import CapabilitySpec
+from llm_judge.control_plane.guardrails import (
+    Guardrail,
+    GuardrailContext,
+    GuardrailDecision,
+    _reset_for_tests,
+    guardrail_context,
+    register_guardrail,
+)
+from llm_judge.control_plane.types import GuardrailDeniedError
+
+
+def _spec() -> CapabilitySpec:
+    return CapabilitySpec(
+        capability_id="CAP-1", sequence_position=0, timeout_seconds=5.0
+    )
+
+
+@pytest.fixture(autouse=True)
+def reset_guardrail_registry() -> None:
+    """Each test runs against an empty module-level registry."""
+    _reset_for_tests()
+
+
+# ---------------------------------------------------------------------
+# GuardrailDecision shape
+# ---------------------------------------------------------------------
+
+
+def test_decision_allow_factory_constructs_allowed_decision() -> None:
+    decision = GuardrailDecision.allow()
+    assert decision.allowed is True
+    assert decision.reason is None
+    assert decision.context == {}
+
+
+def test_decision_deny_factory_requires_reason_and_carries_context() -> None:
+    decision = GuardrailDecision.deny("budget exceeded", capability_id="CAP-7", limit=30.0)
+    assert decision.allowed is False
+    assert decision.reason == "budget exceeded"
+    assert decision.context == {"capability_id": "CAP-7", "limit": 30.0}
+
+
+def test_decision_is_frozen() -> None:
+    decision = GuardrailDecision.allow()
+    with pytest.raises(Exception):
+        decision.allowed = False
+
+
+# ---------------------------------------------------------------------
+# GuardrailContext lifecycle
+# ---------------------------------------------------------------------
+
+
+def test_context_carries_spec_request_id_and_mutable_state() -> None:
+    ctx = GuardrailContext(spec=_spec(), request_id="req-1")
+    assert ctx.spec.capability_id == "CAP-1"
+    assert ctx.request_id == "req-1"
+    assert ctx.guardrail_state == {}
+
+    ctx.guardrail_state["timeout_start"] = 1234.5
+    assert ctx.guardrail_state["timeout_start"] == 1234.5
+
+
+# ---------------------------------------------------------------------
+# guardrail_context with no guardrails registered
+# ---------------------------------------------------------------------
+
+
+def test_empty_registry_yields_context_without_raising() -> None:
+    spec = _spec()
+    with guardrail_context(spec, "req-empty") as ctx:
+        assert ctx.spec is spec
+        assert ctx.request_id == "req-empty"
+
+
+# ---------------------------------------------------------------------
+# Pre-call hook semantics
+# ---------------------------------------------------------------------
+
+
+class _AllowSpy(Guardrail):
+    def __init__(self) -> None:
+        self.pre_called = 0
+        self.post_called = 0
+
+    def pre_call(self, ctx: GuardrailContext) -> GuardrailDecision:
+        self.pre_called += 1
+        return GuardrailDecision.allow()
+
+    def post_call(self, ctx: GuardrailContext) -> GuardrailDecision:
+        self.post_called += 1
+        return GuardrailDecision.allow()
+
+
+class _DenyPreCall(Guardrail):
+    def pre_call(self, ctx: GuardrailContext) -> GuardrailDecision:
+        return GuardrailDecision.deny(
+            "denied for test", capability_id=ctx.spec.capability_id
+        )
+
+
+class _DenyPostCall(Guardrail):
+    def post_call(self, ctx: GuardrailContext) -> GuardrailDecision:
+        return GuardrailDecision.deny("post denied", elapsed=99.9)
+
+
+def test_pre_call_allow_runs_body_and_post_call() -> None:
+    spy = _AllowSpy()
+    body_ran = False
+    with guardrail_context(_spec(), "req-allow", guardrails=[spy]):
+        body_ran = True
+    assert body_ran
+    assert spy.pre_called == 1
+    assert spy.post_called == 1
+
+
+def test_pre_call_deny_raises_and_skips_body() -> None:
+    body_ran = False
+    with pytest.raises(GuardrailDeniedError, match="denied for test"):
+        with guardrail_context(_spec(), "req-deny", guardrails=[_DenyPreCall()]):
+            body_ran = True
+    assert body_ran is False
+
+
+def test_post_call_deny_raises_after_body() -> None:
+    body_ran = False
+    with pytest.raises(GuardrailDeniedError, match="post denied"):
+        with guardrail_context(_spec(), "req-post-deny", guardrails=[_DenyPostCall()]):
+            body_ran = True
+    assert body_ran is True
+
+
+def test_post_call_runs_even_when_body_raises() -> None:
+    spy = _AllowSpy()
+    with pytest.raises(RuntimeError, match="body boom"):
+        with guardrail_context(_spec(), "req-body-raise", guardrails=[spy]):
+            raise RuntimeError("body boom")
+    # Pre and post both fired despite the body raising.
+    assert spy.pre_called == 1
+    assert spy.post_called == 1
+
+
+# ---------------------------------------------------------------------
+# Module-level registry consumed when no override is passed
+# ---------------------------------------------------------------------
+
+
+def test_register_guardrail_adds_to_module_registry() -> None:
+    spy = _AllowSpy()
+    register_guardrail(spy)
+    with guardrail_context(_spec(), "req-registry"):
+        pass
+    assert spy.pre_called == 1
+    assert spy.post_called == 1
+
+
+def test_reset_for_tests_clears_registry() -> None:
+    register_guardrail(_AllowSpy())
+    _reset_for_tests()
+    spy = _AllowSpy()
+    with guardrail_context(_spec(), "req-after-reset"):
+        pass
+    # First spy is gone; the second one was never registered, so it
+    # never fired either.
+    assert spy.pre_called == 0
+    assert spy.post_called == 0

--- a/tests/control_plane/test_guardrails_substrate.py
+++ b/tests/control_plane/test_guardrails_substrate.py
@@ -7,6 +7,8 @@ Commit 4's tests; concrete guardrails (timeout) by Commit 5.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 import pytest
 
 from llm_judge.control_plane.capability_registry import CapabilitySpec
@@ -14,10 +16,10 @@ from llm_judge.control_plane.guardrails import (
     Guardrail,
     GuardrailContext,
     GuardrailDecision,
-    _reset_for_tests,
     guardrail_context,
     register_guardrail,
 )
+from llm_judge.control_plane.guardrails import substrate as _substrate
 from llm_judge.control_plane.types import GuardrailDeniedError
 
 
@@ -28,9 +30,17 @@ def _spec() -> CapabilitySpec:
 
 
 @pytest.fixture(autouse=True)
-def reset_guardrail_registry() -> None:
-    """Each test runs against an empty module-level registry."""
-    _reset_for_tests()
+def isolated_guardrail_registry() -> Iterator[None]:
+    """Each test runs against an empty module-level registry; the
+    production-default registry is restored on teardown so tests
+    that don't override fixtures see the real wiring."""
+    saved = list(_substrate._REGISTERED_GUARDRAILS)
+    _substrate._REGISTERED_GUARDRAILS.clear()
+    try:
+        yield
+    finally:
+        _substrate._REGISTERED_GUARDRAILS.clear()
+        _substrate._REGISTERED_GUARDRAILS.extend(saved)
 
 
 # ---------------------------------------------------------------------
@@ -167,6 +177,8 @@ def test_register_guardrail_adds_to_module_registry() -> None:
 
 
 def test_reset_for_tests_clears_registry() -> None:
+    from llm_judge.control_plane.guardrails import _reset_for_tests
+
     register_guardrail(_AllowSpy())
     _reset_for_tests()
     spy = _AllowSpy()

--- a/tests/control_plane/test_guardrails_substrate_gap_absence.py
+++ b/tests/control_plane/test_guardrails_substrate_gap_absence.py
@@ -1,0 +1,123 @@
+"""CP-F8 substrate gap-absence test.
+
+Per Brief Template v1.3: registers a mock guardrail that always
+denies CAP-1 and verifies the denial actually prevents the
+capability from running. If L1-Pkt-B Commit 4's substrate wrap
+around the orchestrator iteration were reverted, the mock
+guardrail's pre_call decision would have no effect, ``invoke_cap1``
+would still run, and this test would fail.
+
+Evidence D1.1 (operational guardrails substrate) mechanism class
+transition is verified.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from llm_judge.control_plane.guardrails import (
+    Guardrail,
+    GuardrailContext,
+    GuardrailDecision,
+    register_guardrail,
+)
+from llm_judge.control_plane.guardrails import substrate as _substrate
+from llm_judge.control_plane.runner import PlatformRunner
+from llm_judge.control_plane.types import SingleEvaluationRequest
+
+
+@pytest.fixture(autouse=True)
+def isolated_guardrail_registry() -> Iterator[None]:
+    saved = list(_substrate._REGISTERED_GUARDRAILS)
+    _substrate._REGISTERED_GUARDRAILS.clear()
+    try:
+        yield
+    finally:
+        _substrate._REGISTERED_GUARDRAILS.clear()
+        _substrate._REGISTERED_GUARDRAILS.extend(saved)
+
+
+class _DenyCap1Always(Guardrail):
+    """Pre-call denial for CAP-1; everything else passes through."""
+
+    def __init__(self) -> None:
+        self.cap1_invocations_observed_pre = 0
+        self.cap1_invocations_observed_post = 0
+
+    def pre_call(self, ctx: GuardrailContext) -> GuardrailDecision:
+        if ctx.spec.capability_id == "CAP-1":
+            self.cap1_invocations_observed_pre += 1
+            return GuardrailDecision.deny(
+                "test-only Deny on CAP-1", capability_id="CAP-1"
+            )
+        return GuardrailDecision.allow()
+
+    def post_call(self, ctx: GuardrailContext) -> GuardrailDecision:
+        if ctx.spec.capability_id == "CAP-1":
+            self.cap1_invocations_observed_post += 1
+        return GuardrailDecision.allow()
+
+
+def _payload() -> SingleEvaluationRequest:
+    return SingleEvaluationRequest(
+        response="Paris is the capital of France.",
+        source="Paris is the capital of France and its largest city.",
+        rubric_id="chat_quality",
+        caller_id="cap-f8-gap-absence",
+    )
+
+
+def test_pre_call_deny_blocks_capability_invocation(tmp_path: Path) -> None:
+    """The mock guardrail's pre_call returns Deny for CAP-1; the
+    runner must not invoke ``invoke_cap1`` and must record CAP-1 as
+    failed in the integrity list. CAP-2 and CAP-7 must be skipped
+    via the standard cap1_failed path; CAP-5 must still run."""
+    deny = _DenyCap1Always()
+    register_guardrail(deny)
+
+    runner = PlatformRunner(
+        platform_version="cap-f8-gap-absence-sha",
+        transient_root=tmp_path / "transient",
+        runs_root=tmp_path / "runs",
+    )
+    result = runner.run_single_evaluation(_payload())
+
+    # Pre_call observed CAP-1 exactly once.
+    assert deny.cap1_invocations_observed_pre == 1
+    # Pre_call denied before the substrate yielded; no body ran and
+    # post_call did not fire for CAP-1.
+    assert deny.cap1_invocations_observed_post == 0
+
+    # CAP-1 failed (denial recorded as a capability failure).
+    cap1_records = [
+        r for r in result.envelope.integrity if r.capability_id == "CAP-1"
+    ]
+    assert len(cap1_records) == 1
+    assert cap1_records[0].status == "failure"
+    assert cap1_records[0].error_type == "GuardrailDeniedError"
+
+    # CAP-2 and CAP-7 skipped via the existing sibling-skip path.
+    cap2_records = [
+        r for r in result.envelope.integrity if r.capability_id == "CAP-2"
+    ]
+    cap7_records = [
+        r for r in result.envelope.integrity if r.capability_id == "CAP-7"
+    ]
+    assert cap2_records[0].status == "skipped_upstream_failure"
+    assert cap7_records[0].status == "skipped_upstream_failure"
+
+    # CAP-5 ran (manifest written).
+    cap5_records = [
+        r for r in result.envelope.integrity if r.capability_id == "CAP-5"
+    ]
+    assert cap5_records[0].status == "success"
+    assert result.manifest_id
+
+    # Run-level integrity reflects the denial.
+    assert result.integrity.complete is False
+    assert "CAP-1" in result.integrity.missing_capabilities
+    assert result.integrity.reason is not None
+    assert "siblings skipped" in result.integrity.reason

--- a/tests/control_plane/test_timeout_guardrail.py
+++ b/tests/control_plane/test_timeout_guardrail.py
@@ -1,0 +1,69 @@
+"""TimeoutGuardrail unit tests (CP-F12 closure, L1-Pkt-B Commit 5).
+
+Pure guardrail behaviour: pre_call records a start; post_call denies
+on overshoot, allows on undershoot. The CP-F12 gap-absence test
+that exercises the runner end-to-end with a slow mock capability
+ships in Commit 8.
+"""
+
+from __future__ import annotations
+
+import time
+
+from llm_judge.control_plane.capability_registry import CapabilitySpec
+from llm_judge.control_plane.guardrails import (
+    GuardrailContext,
+    TimeoutGuardrail,
+)
+
+
+def _ctx(timeout_seconds: float = 5.0) -> GuardrailContext:
+    return GuardrailContext(
+        spec=CapabilitySpec(
+            capability_id="CAP-1",
+            sequence_position=0,
+            timeout_seconds=timeout_seconds,
+        ),
+        request_id="req-timeout",
+    )
+
+
+def test_pre_call_records_start_perf_counter() -> None:
+    g = TimeoutGuardrail()
+    ctx = _ctx()
+    decision = g.pre_call(ctx)
+    assert decision.allowed is True
+    assert any(k.startswith("timeout_guardrail.") for k in ctx.guardrail_state)
+
+
+def test_post_call_allows_when_elapsed_under_budget() -> None:
+    g = TimeoutGuardrail()
+    ctx = _ctx(timeout_seconds=5.0)
+    g.pre_call(ctx)
+    decision = g.post_call(ctx)
+    assert decision.allowed is True
+    assert decision.reason is None
+
+
+def test_post_call_denies_when_elapsed_exceeds_budget() -> None:
+    g = TimeoutGuardrail()
+    ctx = _ctx(timeout_seconds=0.05)
+    g.pre_call(ctx)
+    time.sleep(0.1)
+    decision = g.post_call(ctx)
+    assert decision.allowed is False
+    assert decision.reason is not None
+    assert "post-completion denial" in decision.reason
+    assert decision.context["capability_id"] == "CAP-1"
+    assert decision.context["configured_timeout_seconds"] == 0.05
+    assert decision.context["observed_duration_seconds"] > 0.05
+
+
+def test_post_call_without_pre_call_allows() -> None:
+    """Defensive guard: if pre_call never ran (substrate misuse),
+    post_call has nothing to measure against and returns Allow
+    rather than denying without evidence."""
+    g = TimeoutGuardrail()
+    ctx = _ctx()
+    decision = g.post_call(ctx)
+    assert decision.allowed is True

--- a/tests/control_plane/test_timeout_guardrail_gap_absence.py
+++ b/tests/control_plane/test_timeout_guardrail_gap_absence.py
@@ -1,0 +1,158 @@
+"""CP-F12 timeout-enforcement gap-absence test.
+
+Per Brief Template v1.3, reframed for Option β post-completion
+denial (L1-Pkt-B Layer 1 chat checkpoint disposition):
+
+  Original Option α framing assumed the guardrail interrupted a
+  running capability and raised within the timeout window. Option β
+  semantics — the chosen strategy because the Layer 1 stack is
+  fully synchronous (Pre-flight 4) — let the capability run to
+  completion and raise post-call once elapsed > configured budget.
+
+Test shape:
+
+  * CAP-1 timeout pinned to 0.1 s via a monkeypatched
+    CAPABILITY_REGISTRY in :mod:`runner`.
+  * ``invoke_cap1`` monkeypatched to sleep 0.3 s and return a
+    valid envelope/dataset_handle pair. The capability succeeds —
+    no exception raised by the body itself.
+  * Run; assert GuardrailDeniedError surfaces, CAP-1 is recorded
+    as a failure with error_type=GuardrailDeniedError, CAP-2 and
+    CAP-7 are skipped via the existing sibling-skip path, CAP-5
+    still runs.
+  * Assert wall-clock elapsed ≥ the sleep duration. Under Option α
+    interruption, the capability would have been cut short at
+    0.1 s and elapsed would be near the timeout. The ≥ 0.3 s
+    assertion locks in the Option β trade-off (no interruption,
+    only post-completion denial).
+
+If L1-Pkt-B Commit 5's TimeoutGuardrail registration were reverted,
+no guardrail would deny the slow capability, the body would
+succeed, CAP-1 would be marked successful, and several assertions
+below would fail.
+
+Evidence D1.2 mechanism class transition is verified: timeout
+budget overshoot is materialised as a runtime denial event.
+
+CP-F12 closure scope note: Option β closes the observability
+surface — overshoot is a structured GuardrailDeniedError with a
+guardrail.timeout_exceeded telemetry event. The "actually bound
+resource consumption" surface (interrupt a runaway capability mid-
+flight) is filed as **CP-F23 candidate** for v1.5 gap analysis.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from llm_judge.control_plane.capability_registry import CapabilitySpec
+from llm_judge.control_plane.envelope import ProvenanceEnvelope
+from llm_judge.control_plane.guardrails import substrate as _substrate
+from llm_judge.control_plane.runner import PlatformRunner
+from llm_judge.control_plane.types import SingleEvaluationRequest
+
+
+@pytest.fixture(autouse=True)
+def isolated_guardrail_registry() -> Iterator[None]:
+    """Snapshot/restore so the production TimeoutGuardrail
+    registration survives the test run while the test itself sees
+    only what it explicitly opts into."""
+    saved = list(_substrate._REGISTERED_GUARDRAILS)
+    try:
+        yield
+    finally:
+        _substrate._REGISTERED_GUARDRAILS.clear()
+        _substrate._REGISTERED_GUARDRAILS.extend(saved)
+
+
+_FAST_TIMEOUT_REGISTRY: tuple[CapabilitySpec, ...] = (
+    CapabilitySpec(capability_id="CAP-1", sequence_position=0, timeout_seconds=0.1),
+    CapabilitySpec(capability_id="CAP-2", sequence_position=1, timeout_seconds=5.0),
+    CapabilitySpec(capability_id="CAP-7", sequence_position=2, timeout_seconds=30.0),
+    CapabilitySpec(capability_id="CAP-5", sequence_position=3, timeout_seconds=5.0),
+)
+
+
+def _payload() -> SingleEvaluationRequest:
+    return SingleEvaluationRequest(
+        response="Paris is the capital of France.",
+        source="Paris is the capital of France and its largest city.",
+        rubric_id="chat_quality",
+        caller_id="cp-f12-gap-absence",
+    )
+
+
+def _slow_invoke_cap1(
+    envelope: ProvenanceEnvelope,
+    payload: SingleEvaluationRequest,
+    *,
+    transient_root: Path | None = None,
+) -> tuple[ProvenanceEnvelope, Any]:
+    """Mock CAP-1 wrapper: sleeps long enough to overshoot the
+    test's tight timeout, then returns a no-op envelope plus a
+    placeholder dataset handle. The handle is never read because
+    CAP-1 failure causes CAP-2 and CAP-7 to skip via the existing
+    sibling-skip path."""
+    del payload, transient_root
+    time.sleep(0.3)
+    return envelope, None
+
+
+def test_post_completion_denial_when_capability_exceeds_budget(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "llm_judge.control_plane.runner.CAPABILITY_REGISTRY",
+        _FAST_TIMEOUT_REGISTRY,
+    )
+    monkeypatch.setattr(
+        "llm_judge.control_plane.runner.invoke_cap1",
+        _slow_invoke_cap1,
+    )
+
+    runner = PlatformRunner(
+        platform_version="cp-f12-gap-absence-sha",
+        transient_root=tmp_path / "transient",
+        runs_root=tmp_path / "runs",
+    )
+
+    started = time.perf_counter()
+    result = runner.run_single_evaluation(_payload())
+    elapsed = time.perf_counter() - started
+
+    # Option β: capability ran to completion; wall-clock elapsed is
+    # at least the sleep duration. Under hypothetical Option α
+    # interruption, elapsed would be near the timeout (0.1 s) and
+    # this assertion would fail.
+    assert elapsed >= 0.25, (
+        f"Expected wall-clock elapsed >= 0.25 s (Option β: capability "
+        f"runs to completion); observed {elapsed:.3f} s"
+    )
+
+    # CAP-1 marked failed; error_type identifies the guardrail denial.
+    cap1_records = [
+        r for r in result.envelope.integrity if r.capability_id == "CAP-1"
+    ]
+    assert len(cap1_records) == 1
+    assert cap1_records[0].status == "failure"
+    assert cap1_records[0].error_type == "GuardrailDeniedError"
+    # duration_ms reflects the actual capability execution (≥ 250 ms).
+    assert cap1_records[0].duration_ms is not None
+    assert cap1_records[0].duration_ms >= 250.0
+
+    # CAP-2 and CAP-7 skipped via the sibling-skip path; CAP-5 ran.
+    statuses = {r.capability_id: r.status for r in result.envelope.integrity}
+    assert statuses["CAP-2"] == "skipped_upstream_failure"
+    assert statuses["CAP-7"] == "skipped_upstream_failure"
+    assert statuses["CAP-5"] == "success"
+
+    # Run-level integrity records the CAP-1 failure.
+    assert result.integrity.complete is False
+    assert "CAP-1" in result.integrity.missing_capabilities
+    assert result.integrity.reason is not None
+    assert "siblings skipped" in result.integrity.reason


### PR DESCRIPTION
## Summary

L1-Pkt-B (Phase 2 Category 2) — operational substrate + first guardrail + capability registry. Closes CP-F9 fully, CP-F12 fully (in observability sense), CP-F8 partially (substrate complete; rate limits / circuit breakers / kill switch are future packets that plug in).

- **CP-F9 — formal capability registry**: `src/llm_judge/control_plane/capability_registry.py` defines `CapabilitySpec` (frozen Pydantic) and `CAPABILITY_REGISTRY` (tuple of 4). `PlatformRunner.run_single_evaluation` now iterates the registry and dispatches by `capability_id` — Option A from the Layer 1 chat checkpoint. `batch_aggregation.VERTICAL_CAPABILITIES` refactored to derive from `CAPABILITY_REGISTRY` (drive-by fix flushed by the gap-absence test).
- **CP-F8 — guardrail substrate**: `src/llm_judge/control_plane/guardrails/` package with `GuardrailDecision`, `GuardrailContext`, `Guardrail` base class, `register_guardrail`, and `guardrail_context()` context manager. Pre-call + post-call hooks fire around every capability invocation; Allow/Deny only (Modify reserved). Telemetry events `guardrail.pre_call` and `guardrail.post_call` ship via existing `emit_event` (ungoverned vocabulary; CP-F7 + CP-F13 absorb in L1-Pkt-D).
- **CP-F12 — TimeoutGuardrail**: First concrete guardrail. **Option β** (post-completion denial) per Layer 1 chat — pre_call records start time, post_call denies if elapsed > `spec.timeout_seconds`. Trade-off documented: capability runs to completion regardless; only its outcome is rejected. **CP-F23 candidate** filed for v1.5 gap analysis on the unmet "actually bound resource consumption" surface.
- **GuardrailDeniedError(ConfigurationError)** added to `types.py` (CP-F20 cluster expansion accepted; reserved namespace for future guardrail subclasses).

Mechanism class transitions:
- D1.1 (operational guardrails substrate): missing → runtime gate
- D1.2 (per-request timeout enforcement): missing → runtime gate
- D2.1 (formal capability registry): convention → runtime gate
- D2.2 (orchestrator consumes registry): convention → runtime gate

## Pre-flight findings (Layer 1 chat checkpoint, v1.1 brief)

| Pre-flight | Disposition |
|---|---|
| 1 — master state | PASS @ 85c7e5c (L1-Pkt-A merge); demo / demo-batch-quick / verify-l1 all green |
| 2 — orchestrator catalog | Single iteration site (`runner.py:run_single_evaluation`); heterogeneous capability signatures + conditional dispatch on CAP-1 failure → Layer 1 chat picked **Option A** (dispatch-by-id inside loop) |
| 3 — latency catalog | 50 cases × 4 capabilities. CAP-1/2/5 P99 < 50 ms → 5 s timeouts; CAP-7 P99 ≈ 3925 ms (warm-up volatility) → 30 s. Sample is small (test runs only); values are conservative starting points |
| 4 — sync/async | All 4 capabilities + orchestrator + batch_runner fully synchronous (no asyncio, no threads) → Layer 1 chat picked **Option β** (post-completion denial) |
| 5 — imports | Clean DAG; no cycles; no late-import pattern needed |

## Initial timeouts applied

| capability | P99 (ms) observed | timeout (s) |
|---|---|---|
| CAP-1 | 32.9 | 5.0 |
| CAP-2 | 44.5 | 5.0 |
| CAP-7 | 3925.1 | 30.0 |
| CAP-5 | 26.5 | 5.0 |

Sample: 50 cases from `make verify-l1` on master @ 85c7e5c. Test runs only — not production traffic. Tune post-deployment.

## Per-commit discipline

8 commits, F19 multi-commit pattern (targeted `git add` per commit, per-commit message). Per-commit `ruff check . --fix`, `mypy .`, and `pytest` all green at every commit boundary. `make preflight` run once before push.

## Test plan

- [x] `make demo` passes — registry-driven iteration produces same chain as before
- [x] `make demo-batch-quick` passes — 10/10 SUCCESS
- [x] `make verify-l1` passes — Precision 1.0000, detection rate within tolerance
- [x] `make preflight` passes — full 9-check chain
- [x] CP-F9 gap-absence test (AST-walking) passes — 2 heuristics
- [x] CP-F8 gap-absence test (mock guardrail Deny) passes
- [x] CP-F12 gap-absence test (slow capability + tight timeout, Option β semantics) passes
- [x] All 1092 prior tests still passing

## Closure status

- CP-F8: **PARTIAL** (substrate exists; rate limits / circuit breakers / kill switch deferred to future packets)
- CP-F9: **FULL**
- CP-F12: **FULL** (observability sense; CP-F23 candidate filed for resource-bounding gap)
- CP-F20 cluster: **expanded by 1** (`GuardrailDeniedError`); structural fix at L1-Pkt-C
- External Contract: **queued for v3.4** (post-Phase-2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)