### PR TITLE
T1.1 · Drift gate repair · YAML schema alignment (Issue 1)

### DIFF
--- a/configs/policies/drift.yaml
+++ b/configs/policies/drift.yaml
@@ -2,19 +2,19 @@ schema_version: "1"
 policy_id: "drift_default"
 
 # Metrics to monitor for drift
-monitored_metrics:
+required_metrics:
   - f1_fail
   - f1_pass
   - precision_fail
   - recall_fail
 
-# Max allowed change between runs
-max_drift:
+# Max allowed change between runs (per-metric thresholds)
+max_metric_drop:
   f1_fail: 0.05
   f1_pass: 0.05
 
-# Minimum runs needed for drift analysis
-min_runs: 2
+# Minimum runs needed for drift analysis (loader: trend_window)
+trend_window: 2
 
 # EPIC-6.1: Heartbeat — alert if no eval_run events within this many hours
 # Set to null/remove to disable heartbeat check


### PR DESCRIPTION
## Summary

- Aligns `configs/policies/drift.yaml` keys to the loader contract at `eval/drift.py:130-152`. Three stale top-level keys renamed: `monitored_metrics → required_metrics`, `max_drift → max_metric_drop`, `min_runs → trend_window`. Values preserved verbatim.
- Closes Phase 1 Issue 1 (T1.1 packet v2.2). Drift-check's `_point_drift_checks` and `_trend_drift_checks` now iterate the configured `required_metrics` list against `max_metric_drop` thresholds; previously they iterated empty dicts because YAML key names didn't match what `load_policy()` reads, leaving the metric-drop signal a no-op.
- Packet ships as 1 commit (Commit 2 dropped per v2.2; Issue 5 reframed and deferred to baseline-promote / runspec-creation packet — see packet for root cause).

## Test plan

- [x] `make preflight` green locally (8m37s, drift status PASS for `math_basic`)
- [x] `make drift-check` (no args, `math_basic` default) → exit 0, status PASS
- [x] `make drift-check SUITE=golden RUBRIC=chat_quality` → status NO_DATA (expected — confirms registry-coverage gap that motivated dropping Commit 2)
- [x] No test or source code references stale keys (`grep -rn "monitored_metrics\|max_drift\|min_runs" tests/ src/` returned no hits)
- [x] Coverage 83.67% (per pytest --cov in preflight)
- [x] Test count 1092 passed (no regression vs baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)